### PR TITLE
Recompile when existence of df.get() input changes

### DIFF
--- a/docs/walkthrough/one-dim.ipynb
+++ b/docs/walkthrough/one-dim.ipynb
@@ -939,7 +939,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fb9f17cc",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "nest_tree"


### PR DESCRIPTION
The existing compiler checks for the existence of a target array to decide whether to use it or the default on a call to df.get().  This then gets hard-wired into the compiled code, so a recompile is needed if the input changes and the target now exists (or doesnt).  This is now baked into the flow hash so the recompile happens when needed.