### PR TITLE
pandas.CategoricalDtype <-> digital_encoding

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -49,9 +49,9 @@ jobs:
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          ruff check . --select=E9,F63,F7,F82 --statistics
+          # exit-zero treats all errors as warnings.
+          ruff check . --exit-zero --statistics
       - name: Test with pytest
         run: |
           python -m pytest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           conda info -a
           conda list
-      - name: Lint with flake8
+      - name: Lint with Ruff
         run: |
           # stop the build if there are Python syntax errors or undefined names
           ruff check . --select=E9,F63,F7,F82 --statistics

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,12 @@ repos:
   hooks:
     - id: nbstripout
 
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.0.257
+  hooks:
+    - id: ruff
+      args: [--fix, --exit-non-zero-on-fix]
+
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1
   hooks:
@@ -23,8 +29,3 @@ repos:
   rev: 22.10.0
   hooks:
     - id: black
-
-- repo: https://github.com/PyCQA/flake8
-  rev: 5.0.4
-  hooks:
-    - id: flake8

--- a/docs/_script/hide_test_cells.py
+++ b/docs/_script/hide_test_cells.py
@@ -11,10 +11,10 @@ notebooks = glob(
 
 # Text to look for in adding tags
 text_search_dict = {
-    "# TEST": "remove_cell",  # Remove the whole cell
-    "# HIDDEN": "remove_cell",  # Remove the whole cell
-    "# NO CODE": "remove_input",  # Remove only the input
-    "# HIDE CODE": "hide_input",  # Hide the input w/ a button to show
+    "# TEST": "remove-cell",  # Remove the whole cell
+    "# HIDDEN": "remove-cell",  # Remove the whole cell
+    "# NO CODE": "remove-input",  # Remove only the input
+    "# HIDE CODE": "hide-input",  # Hide the input w/ a button to show
 }
 
 # Search through each notebook and look for th text, add a tag if necessary

--- a/docs/walkthrough/encoding.ipynb
+++ b/docs/walkthrough/encoding.ipynb
@@ -16,7 +16,7 @@
    "id": "f17c8818",
    "metadata": {
     "tags": [
-     "remove_cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
@@ -217,7 +217,7 @@
    "id": "2ad591bb",
    "metadata": {
     "tags": [
-     "remove_cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
@@ -296,7 +296,7 @@
    "id": "bd549b5e",
    "metadata": {
     "tags": [
-     "remove_cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
@@ -377,7 +377,7 @@
    "id": "7d74e53e",
    "metadata": {
     "tags": [
-     "remove_cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
@@ -477,7 +477,7 @@
    "id": "a016d30f",
    "metadata": {
     "tags": [
-     "remove_cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
@@ -525,7 +525,7 @@
    "id": "28afb335",
    "metadata": {
     "tags": [
-     "remove_cell"
+     "remove-cell"
     ]
    },
    "outputs": [],

--- a/docs/walkthrough/encoding.ipynb
+++ b/docs/walkthrough/encoding.ipynb
@@ -30,7 +30,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d4e7246c",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -690,6 +692,195 @@
     "    _name='WLK_LOC_WLK_FAR'\n",
     ").to_series() == [0,152,474]).all()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb219dc3-dd66-44cd-a7c5-2a1da4bc1467",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Pandas Categorical Dtype\n",
+    "\n",
+    "Dictionary encoding is very similar to the approach used for the pandas Categorical dtype, and\n",
+    "can be used to achieve some of the efficiencies of categorical data, even though xarray lacks\n",
+    "a formal native categorical data representation.  Sharrow's `construct` function for creating\n",
+    "Dataset objects will automatically use dictionary encoding for \"category\" data. \n",
+    "\n",
+    "To demonstrate, we'll load some household data and create a categorical data column."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b765919-69a4-4fb0-b805-9d3b5fed7897",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "hh = sh.example_data.get_households()\n",
+    "hh[\"income_grp\"] = pd.cut(hh.income, bins=[-np.inf,30000,60000,np.inf], labels=['Low', \"Mid\", \"High\"])\n",
+    "hh = hh[[\"income\",\"income_grp\"]]\n",
+    "hh.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "312faa0b-13cf-4649-9835-7a53b5e81a0b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "hh.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c51a88d2-02b1-4502-9f4b-271fbb126699",
+   "metadata": {},
+   "source": [
+    "We'll then create a Dataset using construct."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd1c2fd5-59c6-48cb-bd6e-d2f9dde2aa36",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "hh_dataset = sh.dataset.construct(hh[[\"income\",\"income_grp\"]])\n",
+    "hh_dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "033b3629-a16b-47a4-bb18-10af9c7c4f07",
+   "metadata": {},
+   "source": [
+    "Note that the \"income\" variable remains an integer as expected, but the \"income_grp\" variable, \n",
+    "which had been a \"category\" dtype in pandas, is now stored as an `int8`, giving the \n",
+    "category _index_ of each element (it would be an `int16` or larger if needed, but that's\n",
+    "not necessary with only 3 categories). The information about the labels for the categories is \n",
+    "retained not in the data itself but in the `digital_encoding`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "369442af-1c69-41eb-b530-ea398d6eac7a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "hh_dataset[\"income_grp\"].digital_encoding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58db6505-1c90-475e-8d91-0e2e89ec0f0e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# TESTING\n",
+    "assert hh_dataset[\"income_grp\"].dtype == \"int8\"\n",
+    "assert hh_dataset[\"income_grp\"].digital_encoding.keys() == {'dictionary', 'ordered'}\n",
+    "assert all(hh_dataset[\"income_grp\"].digital_encoding['dictionary'] == np.array(['Low', 'Mid', 'High'], dtype='<U4'))\n",
+    "assert hh_dataset[\"income_grp\"].digital_encoding['ordered'] is True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38f8a6c9-4bca-4e73-82b0-e0996814565a",
+   "metadata": {},
+   "source": [
+    "If you try to make the return trip to a pandas DataFrame using the regular \n",
+    "`xarray.Dataset.to_pandas()` method, the details of the categorical nature\n",
+    "of this variable are lost, and only the int8 index is available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad2f8677-b02c-4d28-892f-3272804bf714",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "hh_dataset.to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95f26992-241f-4982-aa56-f1055a35f969",
+   "metadata": {},
+   "source": [
+    "But, if you use the `single_dim` accessor on the dataset provided by sharrow,\n",
+    "the categorical dtype is restored correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43b94637-c025-4578-9e97-4b6484cb231e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "hh_dataset.single_dim.to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1b86a4b-c19f-4ae9-8a8b-395f53209bc6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# TESTING\n",
+    "pd.testing.assert_frame_equal(\n",
+    "    hh_dataset.single_dim.to_pandas(),\n",
+    "    hh\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e66c294-747d-414c-8e03-b8b551a0e2a9",
+   "metadata": {},
+   "source": [
+    "Note that this automatic handling of categorical data only applies when constructing\n",
+    "or deconstructing a dataset with a single dimension (i.e. the `index` is not a MultiIndex).\n",
+    "Multidimensional datasets use the normal xarray processing, which will dump string\n",
+    "categoricals back into python objects, which is bad news for high performance applications."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2208108a-d051-4941-ad72-b89a05169d81",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "sh.dataset.construct(\n",
+    "    hh[[\"income\",\"income_grp\"]].reset_index().set_index([\"HHID\", \"income\"])\n",
+    ")"
+   ]
   }
  ],
  "metadata": {
@@ -708,7 +899,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.10.9"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/walkthrough/two-dim.ipynb
+++ b/docs/walkthrough/two-dim.ipynb
@@ -32,7 +32,7 @@
    "id": "1f409525",
    "metadata": {
     "tags": [
-     "remove_cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
@@ -288,8 +288,7 @@
    "id": "7b0a4e36",
    "metadata": {
     "tags": [
-     "remove-cell",
-     "remove_cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
@@ -523,8 +522,7 @@
    "id": "03bb0e22",
    "metadata": {
     "tags": [
-     "remove-cell",
-     "remove_cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
@@ -760,8 +758,7 @@
    "id": "dfd6d42a",
    "metadata": {
     "tags": [
-     "remove-cell",
-     "remove_cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
@@ -910,7 +907,7 @@
    "id": "e26a7f58",
    "metadata": {
     "tags": [
-     "remove_cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
@@ -938,7 +935,7 @@
    "id": "4a4fb08e",
    "metadata": {
     "tags": [
-     "remove_cell"
+     "remove-cell"
     ]
    },
    "outputs": [],

--- a/envs/development.yml
+++ b/envs/development.yml
@@ -8,7 +8,7 @@ dependencies:
   # required for testing
   - dask
   - filelock
-  - flake8
+  - ruff
   - jupyter
   - larch>=5.7.1
   - nbmake

--- a/envs/testing.yml
+++ b/envs/testing.yml
@@ -14,7 +14,7 @@ dependencies:
   - numexpr
   - sparse
   - filelock
-  - flake8
+  - ruff
   # required for testing
   - pytest
   - pytest-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,13 @@ default_section = "THIRDPARTY"
 known_first_party = "sharrow"
 
 [tool.ruff]
-# Enable flake8-bugbear (`B`) rules.
-select = ["E", "F", "B"]
+# Enable flake8-bugbear (`B`) and pyupgrade ('UP') rules.
+select = ["E", "F", "B", "UP"]
 fix = true
 ignore-init-module-imports = true
 line-length = 120
 ignore = ["B905"]
+target-version = "py39"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,14 @@ float_to_top = true
 default_section = "THIRDPARTY"
 known_first_party = "sharrow"
 
+[tool.ruff]
+# Enable flake8-bugbear (`B`) rules.
+select = ["E", "F", "B"]
+fix = true
+ignore-init-module-imports = true
+line-length = 120
+ignore = ["B905"]
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-v --nbmake --disable-warnings"

--- a/sharrow/__init__.py
+++ b/sharrow/__init__.py
@@ -3,6 +3,7 @@ from xarray import DataArray
 from . import dataset, example_data, selectors, shared_memory, sparse
 from ._infer_version import __version__, __version_tuple__
 from .dataset import Dataset
+from .datastore import DataStore
 from .digital_encoding import array_decode, array_encode
 from .flows import CacheMissWarning, Flow
 from .relationships import DataTree, Relationship

--- a/sharrow/__init__.py
+++ b/sharrow/__init__.py
@@ -8,3 +8,24 @@ from .digital_encoding import array_decode, array_encode
 from .flows import CacheMissWarning, Flow
 from .relationships import DataTree, Relationship
 from .table import Table, concat_tables
+
+__all__ = [
+    "__version__",
+    "__version_tuple__",
+    "DataArray",
+    "Dataset",
+    "DataStore",
+    "DataTree",
+    "Relationship",
+    "Table",
+    "CacheMissWarning",
+    "Flow",
+    "example_data",
+    "array_decode",
+    "array_encode",
+    "concat_tables",
+    "dataset",
+    "selectors",
+    "shared_memory",
+    "sparse",
+]

--- a/sharrow/aster.py
+++ b/sharrow/aster.py
@@ -1,7 +1,6 @@
 import ast
 import io
 import logging
-import sys
 import tokenize
 
 try:
@@ -25,37 +24,21 @@ def unparse_(*args):
         raise
 
 
-if sys.version_info >= (3, 8):
-    ast_Constant_Type = ast.Constant
+ast_Constant_Type = ast.Constant
 
-    def ast_String_value(x):
-        return x.value if isinstance(x, ast.Str) else x
 
-    ast_TupleIndex_Type = ast.Tuple
+def ast_String_value(x):
+    return x.value if isinstance(x, ast.Str) else x
 
-    def ast_Index_Value(x):
-        return x
 
-    ast_Constant = ast.Constant
-else:
-    ast_Constant_Type = (ast.Index, ast.Constant, ast.Str, ast.Num)
+ast_TupleIndex_Type = ast.Tuple
 
-    def ast_String_value(x):
-        return (
-            x.s
-            if isinstance(x, ast.Str)
-            else ast_String_value(x.value)
-            if isinstance(x, ast.Index)
-            else x
-        )
 
-    ast_TupleIndex_Type = (ast.Index, ast.Tuple)
+def ast_Index_Value(x):
+    return x
 
-    def ast_Index_Value(x):
-        return x.value if isinstance(x, ast.Index) else x
 
-    def ast_Constant(x):
-        return ast.Constant(x, kind=None)
+ast_Constant = ast.Constant
 
 
 def _isNone(c):
@@ -467,16 +450,9 @@ class RewriteForNumba(ast.NodeTransformer):
                     if isinstance(n, int):
                         elts.append(ast.Name(id=f"_arg{n:02}", ctx=ast.Load()))
                     elif isinstance(n, dict):
-                        if sys.version_info >= (3, 8):
-                            elts.append(
-                                ast.Constant(n=n[missing_dim_value], ctx=ast.Load())
-                            )
-                        else:
-                            elts.append(
-                                ast.Constant(
-                                    n[missing_dim_value], kind=None, ctx=ast.Load()
-                                )
-                            )
+                        elts.append(
+                            ast.Constant(n=n[missing_dim_value], ctx=ast.Load())
+                        )
                     else:
                         elts.append(n)
                     logger.debug(f"ELT {unparse_(elts[-1])}")

--- a/sharrow/aster.py
+++ b/sharrow/aster.py
@@ -9,7 +9,9 @@ try:
 except ImportError:
     from astunparse import unparse as _unparse
 
-    unparse = lambda *args: _unparse(*args).strip("\n")
+    def unparse(*args):
+        return _unparse(*args).strip("\n")
+
 
 logger = logging.getLogger("sharrow.aster")
 
@@ -25,20 +27,35 @@ def unparse_(*args):
 
 if sys.version_info >= (3, 8):
     ast_Constant_Type = ast.Constant
-    ast_String_value = lambda x: x.value if isinstance(x, ast.Str) else x
+
+    def ast_String_value(x):
+        return x.value if isinstance(x, ast.Str) else x
+
     ast_TupleIndex_Type = ast.Tuple
-    ast_Index_Value = lambda x: x
+
+    def ast_Index_Value(x):
+        return x
+
     ast_Constant = ast.Constant
 else:
     ast_Constant_Type = (ast.Index, ast.Constant, ast.Str, ast.Num)
-    ast_String_value = (
-        lambda x: x.s
-        if isinstance(x, ast.Str)
-        else (ast_String_value(x.value) if isinstance(x, ast.Index) else x)
-    )
+
+    def ast_String_value(x):
+        return (
+            x.s
+            if isinstance(x, ast.Str)
+            else ast_String_value(x.value)
+            if isinstance(x, ast.Index)
+            else x
+        )
+
     ast_TupleIndex_Type = (ast.Index, ast.Tuple)
-    ast_Index_Value = lambda x: x.value if isinstance(x, ast.Index) else x
-    ast_Constant = lambda x: ast.Constant(x, kind=None)
+
+    def ast_Index_Value(x):
+        return x.value if isinstance(x, ast.Index) else x
+
+    def ast_Constant(x):
+        return ast.Constant(x, kind=None)
 
 
 def _isNone(c):
@@ -69,7 +86,6 @@ def extract_names(command):
 
 
 def extract_names_2(command):
-
     if not isinstance(command, str):
         return set(), dict(), dict()
 
@@ -364,7 +380,8 @@ class RewriteForNumba(ast.NodeTransformer):
                 except:  # noqa: E722
                     unparsed = f"{type(node1)} not unparseable"
                 logger.debug(
-                    f"RewriteForNumba({self.spacename}|{self.rawalias}).{tag} [{type(node1).__name__}]= {unparsed}",
+                    f"RewriteForNumba({self.spacename}|{self.rawalias}).{tag} "
+                    f"[{type(node1).__name__}]= {unparsed}",
                 )
             else:
                 try:
@@ -376,7 +393,9 @@ class RewriteForNumba(ast.NodeTransformer):
                 except:  # noqa: E722
                     unparsed2 = f"{type(node2).__name__} not unparseable"
                 logger.debug(
-                    f"RewriteForNumba({self.spacename}|{self.rawalias}).{tag} [{type(node1).__name__},{type(node2).__name__}]= {unparsed1} => {unparsed2}",
+                    f"RewriteForNumba({self.spacename}|{self.rawalias}).{tag} "
+                    f"[{type(node1).__name__},{type(node2).__name__}]= "
+                    f"{unparsed1} => {unparsed2}",
                 )
 
     def generic_visit(self, node):
@@ -402,8 +421,8 @@ class RewriteForNumba(ast.NodeTransformer):
                     topname == pref_topname and not self.swallow_errors
                 ):
                     raise KeyError(f"{topname}..{attr}")
-                # we originally raised a KeyError here regardless, but what if we just
-                # give back the original node, and see if other spaces,
+                # we originally raised a KeyError here regardless, but what if
+                # we just give back the original node, and see if other spaces,
                 # possibly fallback spaces, might work?  If nothing works then
                 # it will still eventually error out when compiling?
                 # The swallow errors option allows us to continue processing
@@ -489,7 +508,6 @@ class RewriteForNumba(ast.NodeTransformer):
 
         digital_encoding = self.digital_encodings.get(attr, None)
         if digital_encoding is not None:
-
             dictionary = digital_encoding.get("dictionary", None)
             offset_source = digital_encoding.get("offset_source", None)
             if dictionary is not None:
@@ -606,7 +624,8 @@ class RewriteForNumba(ast.NodeTransformer):
                     result,
                 )
                 return result
-            # for XXX[YYY,ZZZ], XXX is a space name and YYY is a literal value and ZZZ is a literal value: skims['SOV_TIME','MD']
+            # for XXX[YYY,ZZZ], XXX is a space name and YYY is a literal value and
+            # ZZZ is a literal value: skims['SOV_TIME','MD']
             if (
                 node.value.id == self.spacename
                 and isinstance(ast_Index_Value(node.slice), ast.Tuple)
@@ -726,7 +745,6 @@ class RewriteForNumba(ast.NodeTransformer):
         if self.bool_wrapping and isinstance(
             node.op, (ast.BitAnd, ast.BitOr, ast.BitXor)
         ):
-
             result = ast.BinOp(
                 left=bool_wrap(left),
                 op=node.op,
@@ -743,7 +761,6 @@ class RewriteForNumba(ast.NodeTransformer):
         return result
 
     def visit_Call(self, node):
-
         result = None
         # implement ActivitySim's "reverse" skims
         if (

--- a/sharrow/categorical.py
+++ b/sharrow/categorical.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import numpy as np
 import xarray as xr
 
+
 class ArrayIsNotCategoricalError(TypeError):
     """The array is not an encoded categorical array."""
+
 
 @xr.register_dataarray_accessor("cat")
 class _Categorical:
@@ -12,7 +14,7 @@ class _Categorical:
     Accessor for pseudo-categorical arrays.
     """
 
-    __slots__ = ("dataarray", )
+    __slots__ = ("dataarray",)
 
     def __init__(self, dataarray: xr.DataArray):
         self.dataarray = dataarray
@@ -22,7 +24,7 @@ class _Categorical:
         try:
             return self.dataarray.attrs["digital_encoding"]["dictionary"]
         except KeyError:
-            raise ArrayIsNotCategoricalError()
+            raise ArrayIsNotCategoricalError() from None
 
     @property
     def ordered(self):

--- a/sharrow/categorical.py
+++ b/sharrow/categorical.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+
+class ArrayIsNotCategoricalError(TypeError):
+    """The array is not an encoded categorical array."""
+
+@xr.register_dataarray_accessor("cat")
+class _Categorical:
+    """
+    Accessor for pseudo-categorical arrays.
+    """
+
+    __slots__ = ("dataarray", )
+
+    def __init__(self, dataarray: xr.DataArray):
+        self.dataarray = dataarray
+
+    @property
+    def categories(self):
+        try:
+            return self.dataarray.attrs["digital_encoding"]["dictionary"]
+        except KeyError:
+            raise ArrayIsNotCategoricalError()
+
+    @property
+    def ordered(self):
+        return self.dataarray.attrs["digital_encoding"].get("ordered", True)
+
+    def category_array(self) -> np.ndarray:
+        arr = np.asarray(self.categories)
+        if arr.dtype.kind == "O":
+            arr = arr.astype(str)
+        return arr
+
+    def is_categorical(self) -> bool:
+        return "dictionary" in self.dataarray.attrs.get("digital_encoding", {})

--- a/sharrow/dataset.py
+++ b/sharrow/dataset.py
@@ -1303,7 +1303,7 @@ def from_named_objects(*args):
         try:
             name = a.name
         except AttributeError:
-            raise ValueError(f"argument {n} has no name")
+            raise ValueError(f"argument {n} has no name") from None
         if name is None:
             raise ValueError(f"the name for argument {n} is None")
         objs[name] = a

--- a/sharrow/dataset.py
+++ b/sharrow/dataset.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import base64
 import hashlib
@@ -13,6 +15,7 @@ from xarray import DataArray, Dataset
 
 from .accessors import register_dataset_method
 from .aster import extract_all_name_tokens
+from .categorical import _Categorical  # noqa
 from .table import Table
 
 logger = logging.getLogger("sharrow")
@@ -92,20 +95,20 @@ def construct(source):
     if isinstance(source, pd.DataFrame):
         source = dataset_from_dataframe_fast(source)  # xarray default can be slow
     elif isinstance(source, (Table, pa.Table)):
-        source = xr.Dataset.from_table(source)
-    elif isinstance(source, (pa.Table)):
-        source = xr.Dataset.from_table(source)
+        source = from_table(source)
     elif isinstance(source, xr.Dataset):
         pass  # don't do the superclass things
     elif isinstance(source, Sequence) and all(isinstance(i, str) for i in source):
-        source = xr.Dataset.from_table(pa.table({i: [] for i in source}))
+        source = from_table(pa.table({i: [] for i in source}))
     else:
         source = xr.Dataset(source)
     return source
 
 
 def dataset_from_dataframe_fast(
-    dataframe: pd.DataFrame, sparse: bool = False
+    dataframe: pd.DataFrame,
+    sparse: bool = False,
+    preserve_cat: bool = True,
 ) -> "Dataset":
     """Convert a pandas.DataFrame into an xarray.Dataset
 
@@ -175,11 +178,26 @@ def dataset_from_dataframe_fast(
     index_name = idx.name if idx.name is not None else "index"
     # Cast to a NumPy array first, in case the Series is a pandas Extension
     # array (which doesn't have a valid NumPy dtype)
-    arrays = {
-        name: ([index_name], np.asarray(dataframe[name].values))
-        for name in dataframe.columns
-        if name != index_name
-    }
+    arrays = {}
+    for name in dataframe.columns:
+        if name != index_name:
+            if dataframe[name].dtype == "category" and preserve_cat:
+                cat = dataframe[name].cat
+                categories = np.asarray(cat.categories)
+                if categories.dtype.kind == "O":
+                    categories = categories.astype(str)
+                arrays[name] = (
+                    [index_name],
+                    np.asarray(cat.codes),
+                    {
+                        "digital_encoding": {
+                            "dictionary": categories,
+                            "ordered": cat.ordered,
+                        }
+                    },
+                )
+            else:
+                arrays[name] = ([index_name], np.asarray(dataframe[name].values))
     return Dataset(arrays, coords={index_name: (index_name, dataframe.index.values)})
 
 
@@ -197,7 +215,8 @@ def from_table(
         Table from which to use data and indices.
     index_name : str, default 'index'
         This name will be given to the default dimension index, if
-        none is given.  Ignored if `index` is given explicitly.
+        none is given.  Ignored if `index` is given explicitly and
+        it already has a name.
     index : Index-like, optional
         Use this index instead of a default RangeIndex.
 
@@ -218,10 +237,21 @@ def from_table(
         raise ValueError(
             "cannot attach a non-unique MultiIndex and convert into xarray"
         )
-    arrays = [
-        (tbl.column_names[n], np.asarray(tbl.column(n)))
-        for n in range(len(tbl.column_names))
-    ]
+    arrays = []
+    metadata = {}
+    for n in range(len(tbl.column_names)):
+        c = tbl.column(n)
+        if isinstance(c.type, pa.DictionaryType):
+            cc = c.combine_chunks()
+            arrays.append((tbl.column_names[n], np.asarray(cc.indices)))
+            metadata[tbl.column_names[n]] = {
+                "digital_encoding": {
+                    "dictionary": cc.dictionary,
+                    "ordered": cc.type.ordered,
+                }
+            }
+        else:
+            arrays.append((tbl.column_names[n], np.asarray(c)))
     result = xr.Dataset()
     if isinstance(index, pd.MultiIndex):
         dims = tuple(
@@ -231,11 +261,17 @@ def from_table(
         for dim, lev in zip(dims, index.levels):
             result[dim] = (dim, lev)
     else:
-        index_name = index.name if index.name is not None else "index"
+        try:
+            if index.name is not None:
+                index_name = index.name
+        except AttributeError:
+            pass
         dims = (index_name,)
         result[index_name] = (dims, index)
 
     result._set_numpy_data_from_dataframe(index, arrays, dims)
+    for k, v in metadata.items():
+        result[k].attrs.update(v)
     return result
 
 
@@ -627,27 +663,11 @@ def from_zarr_with_attr(*args, **kwargs):
     for k in obj:
         attrs = {}
         for aname, avalue in obj[k].attrs.items():
-            if (
-                isinstance(avalue, str)
-                and avalue.startswith(" {")
-                and avalue.endswith("} ")
-            ):
-                avalue = ast.literal_eval(avalue[1:-1])
-            if isinstance(avalue, str) and avalue == " < None > ":
-                avalue = None
-            attrs[aname] = avalue
+            attrs[aname] = _from_evalable_string(avalue)
         obj[k] = obj[k].assign_attrs(attrs)
     attrs = {}
     for aname, avalue in obj.attrs.items():
-        if (
-            isinstance(avalue, str)
-            and avalue.startswith(" {")
-            and avalue.endswith("} ")
-        ):
-            avalue = ast.literal_eval(avalue[1:-1])
-        if isinstance(avalue, str) and avalue == " < None > ":
-            avalue = None
-        attrs[aname] = avalue
+        attrs[aname] = _from_evalable_string(avalue)
     obj = obj.assign_attrs(attrs)
     return obj
 
@@ -691,10 +711,122 @@ class _SingleDim:
     def size(self):
         return self.dataset.dims[self.dim_name]
 
-    def to_pyarrow(self):
-        return pa.Table.from_pydict(
-            {k: pa.array(v.to_numpy()) for k, v in self.dataset.variables.items()}
+    def _to_pydict(self):
+        columns = [k for k in self.dataset.variables if k != self.dim_name]
+        data = []
+        for k in columns:
+            a = self.dataset._variables[k]
+            if (
+                "digital_encoding" in a.attrs
+                and "dictionary" in a.attrs["digital_encoding"]
+            ):
+                de = a.attrs["digital_encoding"]
+                data.append(
+                    pd.Categorical.from_codes(
+                        a.values,
+                        de["dictionary"],
+                        de.get("ordered"),
+                    )
+                )
+            else:
+                data.append(a.values)
+        return dict(zip(columns, data))
+
+    def to_pyarrow(self) -> pa.Table:
+        columns = [k for k in self.dataset.variables if k != self.dim_name]
+        data = []
+        for k in columns:
+            a = self.dataset._variables[k]
+            if (
+                "digital_encoding" in a.attrs
+                and "dictionary" in a.attrs["digital_encoding"]
+            ):
+                de = a.attrs["digital_encoding"]
+                data.append(
+                    pa.DictionaryArray.from_arrays(
+                        a.values,
+                        de["dictionary"],
+                        ordered=de.get("ordered", False),
+                    )
+                )
+            else:
+                data.append(pa.array(a.values))
+        content = dict(zip(columns, data))
+        content[self.dim_name] = self.index
+        return pa.Table.from_pydict(content)
+
+    def to_parquet(self, filename):
+        import pyarrow.parquet as pq
+
+        t = self.to_pyarrow()
+        pq.write_table(t, filename)
+
+    def to_pandas(self) -> pd.DataFrame:
+        """
+        Convert this dataset into a pandas DataFrame.
+
+        The resulting DataFrame is always a copy of the data in the dataset.
+
+        Returns
+        -------
+        pandas.DataFrame
+        """
+        return pd.DataFrame(self._to_pydict(), index=self.index, copy=True)
+
+    def eval(
+        self,
+        expr: str,
+        parser: str = "pandas",
+        engine: str | None = None,
+        local_dict=None,
+        global_dict=None,
+    ):
+        """
+        Evaluate a Python expression as a string using various backends.
+
+        Parameters
+        ----------
+        expr : str
+            The expression to evaluate. This string cannot contain any Python
+            `statements
+            <https://docs.python.org/3/reference/simple_stmts.html#simple-statements>`__,
+            only Python `expressions
+            <https://docs.python.org/3/reference/simple_stmts.html#expression-statements>`__.
+        parser : {'pandas', 'python'}, default 'pandas'
+            The parser to use to construct the syntax tree from the expression. The
+            default of ``'pandas'`` parses code slightly different than standard
+            Python. Alternatively, you can parse an expression using the
+            ``'python'`` parser to retain strict Python semantics.  See the
+            :ref:`enhancing performance <enhancingperf.eval>` documentation for
+            more details.
+        engine : {'python', 'numexpr'}, default 'numexpr'
+            The engine used to evaluate the expression. Supported engines are
+            - None : tries to use ``numexpr``, falls back to ``python``
+            - ``'numexpr'`` : This default engine evaluates pandas objects using
+              numexpr for large speed ups in complex expressions with large frames.
+            - ``'python'`` : Performs operations as if you had ``eval``'d in top
+              level python. This engine is generally not that useful.
+        local_dict : dict or None, optional
+            A dictionary of local variables, taken from locals() by default.
+        global_dict : dict or None, optional
+            A dictionary of global variables, taken from globals() by default.
+
+        Returns
+        -------
+        DataArray or numeric scalar
+        """
+        result = pd.eval(
+            expr,
+            parser=parser,
+            engine=engine,
+            local_dict=local_dict,
+            global_dict=global_dict,
+            resolvers=[self.dataset],
         )
+        if result.size == self.size:
+            return DataArray(np.asarray(result), coords=self.dataset.coords)
+        else:
+            return result
 
 
 @xr.register_dataarray_accessor("single_dim")
@@ -724,6 +856,39 @@ class _SingleDimArray:
         if self.dim_name == name:
             return self.dataarray
         return self.dataarray.rename({self.dim_name: name})
+
+    def to_pandas(self) -> pd.Series:
+        """
+        Convert this array into a pandas Series.
+
+        If this array is categorical (i.e. with a simple dictionary-based
+        digital encoding) then the result will be a Series with categorical dtype.
+
+        The DataArray's `name` attribute is preserved in the result.
+        """
+        if self.dataarray.cat.is_categorical():
+            return pd.Series(
+                pd.Categorical.from_codes(
+                    self.dataarray,
+                    self.dataarray.cat.categories,
+                    self.dataarray.cat.ordered,
+                ),
+                index=self.index,
+                name=self.dataarray.name,
+            )
+        else:
+            result = self.dataarray.to_pandas()
+            if self.dataarray.name:
+                result = result.rename(self.dataarray.name)
+            return result
+
+    def to_pyarrow(self):
+        if self.dataarray.cat.is_categorical():
+            return pa.DictionaryArray.from_arrays(
+                self.dataarray.data, self.dataarray.cat.categories
+            )
+        else:
+            return pa.array(self.dataarray.data)
 
 
 @xr.register_dataset_accessor("iloc")
@@ -858,6 +1023,58 @@ def to_zarr_zip(self, *args, **kwargs):
     return super().to_zarr(*args, **kwargs)
 
 
+def _to_ast_literal(x):
+    if isinstance(x, dict):
+        return (
+            "{"
+            + ", ".join(
+                f"{_to_ast_literal(k)}: {_to_ast_literal(v)}" for k, v in x.items()
+            )
+            + "}"
+        )
+    elif isinstance(x, list):
+        return "[" + ", ".join(_to_ast_literal(i) for i in x) + "]"
+    elif isinstance(x, tuple):
+        return "(" + ", ".join(_to_ast_literal(i) for i in x) + ")"
+    elif isinstance(x, pd.Index):
+        return _to_ast_literal(x.to_list())
+    elif isinstance(x, np.ndarray):
+        return _to_ast_literal(list(x))
+    else:
+        return repr(x)
+
+
+def _to_evalable_string(x):
+    if x is None:
+        return " < None > "
+    elif x is True:
+        return " < True > "
+    elif x is False:
+        return " < False > "
+    else:
+        return f" {_to_ast_literal(x)} "
+
+
+def _from_evalable_string(x):
+    if isinstance(x, str):
+        # if x.startswith(" {") and x.endswith("} "):
+        #     return ast.literal_eval(x[1:-1])
+        if x == " < None > ":
+            return None
+        if x == " < True > ":
+            return True
+        if x == " < False > ":
+            return False
+        if x.startswith(" ") and x.endswith(" "):
+            try:
+                return ast.literal_eval(x.strip(" "))
+            except Exception:
+                print(x)
+                raise
+    else:
+        return x
+
+
 @register_dataset_method
 def to_zarr_with_attr(self, *args, **kwargs):
     """
@@ -938,19 +1155,17 @@ def to_zarr_with_attr(self, *args, **kwargs):
     for k in self:
         attrs = {}
         for aname, avalue in self[k].attrs.items():
-            if isinstance(avalue, dict):
-                avalue = f" {avalue!r} "
-            if avalue is None:
-                avalue = " < None > "
-            attrs[aname] = avalue
+            attrs[aname] = _to_evalable_string(avalue)
         obj[k] = self[k].assign_attrs(attrs)
+    if hasattr(self, "coords"):
+        for k in self.coords:
+            attrs = {}
+            for aname, avalue in self.coords[k].attrs.items():
+                attrs[aname] = _to_evalable_string(avalue)
+            obj.coords[k] = self.coords[k].assign_attrs(attrs)
     attrs = {}
     for aname, avalue in self.attrs.items():
-        if isinstance(avalue, dict):
-            avalue = f" {avalue!r} "
-        if avalue is None:
-            avalue = " < None > "
-        attrs[aname] = avalue
+        attrs[aname] = _to_evalable_string(avalue)
     obj = obj.assign_attrs(attrs)
     return obj.to_zarr(*args, **kwargs)
 

--- a/sharrow/dataset.py
+++ b/sharrow/dataset.py
@@ -5,7 +5,8 @@ import base64
 import hashlib
 import logging
 import re
-from typing import Any, Hashable, Mapping, Sequence
+from collections.abc import Hashable, Mapping, Sequence
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -109,7 +110,7 @@ def dataset_from_dataframe_fast(
     dataframe: pd.DataFrame,
     sparse: bool = False,
     preserve_cat: bool = True,
-) -> "Dataset":
+) -> Dataset:
     """Convert a pandas.DataFrame into an xarray.Dataset
 
     Each column will be converted into an independent variable in the
@@ -693,7 +694,7 @@ class _SingleDim:
 
     __slots__ = ("dataset", "dim_name")
 
-    def __init__(self, dataset: "Dataset"):
+    def __init__(self, dataset: Dataset):
         self.dataset = dataset
         if len(self.dataset.dims) != 1:
             raise ValueError("single_dim implies a single dimension dataset")
@@ -837,7 +838,7 @@ class _SingleDimArray:
 
     __slots__ = ("dataarray", "dim_name")
 
-    def __init__(self, dataarray: "DataArray"):
+    def __init__(self, dataarray: DataArray):
         self.dataarray = dataarray
         if len(self.dataarray.dims) != 1:
             raise ValueError("single_dim implies a single dimension dataset")
@@ -907,10 +908,10 @@ class _iLocIndexer:
 
     __slots__ = ("dataset",)
 
-    def __init__(self, dataset: "Dataset"):
+    def __init__(self, dataset: Dataset):
         self.dataset = dataset
 
-    def __getitem__(self, key: Mapping[Hashable, Any]) -> "Dataset":
+    def __getitem__(self, key: Mapping[Hashable, Any]) -> Dataset:
         if not is_dict_like(key):
             if len(self.dataset.dims) == 1:
                 dim_name = self.dataset.dims.__iter__().__next__()

--- a/sharrow/datastore.py
+++ b/sharrow/datastore.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import datetime
+import os
+import shutil
+from collections.abc import Collection
+from pathlib import Path
+
+import pandas as pd
+import xarray as xr
+import yaml
+
+from .dataset import construct, from_zarr_with_attr
+from .relationships import DataTree, Relationship
+
+
+def timestamp():
+    return datetime.datetime.now(datetime.timezone.utc).astimezone().isoformat()
+
+
+class ReadOnlyError(ValueError):
+    """This object is read-only."""
+
+
+def _read_parquet(filename, index_col=None) -> xr.Dataset:
+    import pyarrow.parquet as pq
+
+    from sharrow.dataset import from_table
+
+    content = pq.read_table(filename)
+    if index_col is not None:
+        index = content.column(index_col)
+        content = content.drop([index_col])
+    else:
+        index = None
+    x = from_table(content, index=index, index_name=index_col or "index")
+    return x
+
+
+class DataStore:
+    metadata_filename: str = "metadata.yaml"
+    checkpoint_subdir: str = "checkpoints"
+    LATEST = "_"
+    _BY_OFFSET = "digitizedOffset"
+
+    def __init__(self, directory: Path | None, mode="a", storage_format: str = "zarr"):
+        self._directory = Path(directory) if directory else directory
+        self._mode = mode
+        self._checkpoints = {}
+        self._checkpoint_order = []
+        self._tree = DataTree(root_node_name=False)
+        self._keep_digitized = False
+        assert storage_format in {"zarr", "parquet", "hdf5"}
+        self._storage_format = storage_format
+        try:
+            self.read_metadata()
+        except FileNotFoundError:
+            pass
+
+    @property
+    def directory(self) -> Path:
+        if self._directory is None:
+            raise NotADirectoryError("no directory set")
+        return self._directory
+
+    def __setitem__(self, key: str, value: xr.Dataset | pd.DataFrame):
+        assert isinstance(key, str)
+        if self._mode == "r":
+            raise ReadOnlyError
+        if isinstance(value, xr.Dataset):
+            self._set_dataset(key, value)
+        elif isinstance(value, pd.DataFrame):
+            self._set_dataset(key, construct(value))
+        else:
+            raise TypeError(f"cannot put {type(value)}")
+
+    def __getitem__(self, key: str):
+        assert isinstance(key, str)
+        return self.get_dataset(key)
+
+    def clone(self, mode="a"):
+        """
+        Create a clone of this dataset manager.
+
+        The clone has the same active datasets as the original (and the data
+        shares the same memory) but it does not retain the checkpoint metadata
+        and is not connected to the checkpoint store.
+
+        Returns
+        -------
+        DataStore
+        """
+        duplicate = self.__class__(None, mode=mode)
+        duplicate._tree = self._tree
+        return duplicate
+
+    def _set_dataset(
+        self,
+        name: str,
+        data: xr.Dataset,
+        last_checkpoint: str = None,
+    ) -> None:
+        if self._mode == "r":
+            raise ReadOnlyError
+        data_vars = {}
+        coords = {}
+        for k, v in data.coords.items():
+            coords[k] = v.assign_attrs(last_checkpoint=last_checkpoint)
+        for k, v in data.items():
+            if k in coords:
+                continue
+            data_vars[k] = v.assign_attrs(last_checkpoint=last_checkpoint)
+        data = xr.Dataset(data_vars=data_vars, coords=coords, attrs=data.attrs)
+        self._tree.add_dataset(name, data)
+
+    def _update_dataset(
+        self,
+        name: str,
+        data: xr.Dataset,
+        last_checkpoint=None,
+    ) -> xr.Dataset:
+        if self._mode == "r":
+            raise ReadOnlyError
+        if not isinstance(data, xr.Dataset):
+            raise TypeError(type(data))
+        partial_update = self._tree.get_subspace(name, default_empty=True)
+        for k, v in data.items():
+            if k in data.coords:
+                continue
+            assert v.name == k
+            partial_update = self._update_dataarray(
+                name, v, last_checkpoint, partial_update=partial_update
+            )
+        for k, v in data.coords.items():
+            assert v.name == k
+            partial_update = self._update_dataarray(
+                name, v, last_checkpoint, as_coord=True, partial_update=partial_update
+            )
+        return partial_update
+
+    def _update_dataarray(
+        self,
+        name: str,
+        data: xr.DataArray,
+        last_checkpoint=None,
+        as_coord=False,
+        partial_update=None,
+    ) -> xr.Dataset:
+        if self._mode == "r":
+            raise ReadOnlyError
+        if partial_update is None:
+            base_data = self._tree.get_subspace(name, default_empty=True)
+        else:
+            base_data = partial_update
+        if isinstance(data, xr.DataArray):
+            if as_coord:
+                updated_dataset = base_data.assign_coords(
+                    {data.name: data.assign_attrs(last_checkpoint=last_checkpoint)}
+                )
+            else:
+                updated_dataset = base_data.assign(
+                    {data.name: data.assign_attrs(last_checkpoint=last_checkpoint)}
+                )
+            self._tree = self._tree.replace_datasets(
+                {name: updated_dataset}, redigitize=self._keep_digitized
+            )
+            return updated_dataset
+        else:
+            raise TypeError(type(data))
+
+    def update(
+        self,
+        name: str,
+        obj: xr.Dataset | xr.DataArray,
+        last_checkpoint: str = None,
+    ):
+        if isinstance(obj, xr.Dataset):
+            self._update_dataset(name, obj, last_checkpoint=last_checkpoint)
+        elif isinstance(obj, xr.DataArray):
+            self._update_dataarray(name, obj, last_checkpoint=last_checkpoint)
+        else:
+            raise TypeError(type(obj))
+
+    def set_data(self, name: str, data: xr.Dataset, relationships=None):
+        self.__setitem__(name, data)
+        if relationships is not None:
+            if isinstance(relationships, (str, Relationship)):
+                relationships = [relationships]
+            for r in relationships:
+                self._tree.add_relationship(r)
+
+    def get_dataset(self, name: str, columns: Collection[str] = None) -> xr.Dataset:
+        if columns is None:
+            return self._tree.get_subspace(name)
+        else:
+            return xr.Dataset({c: self._tree[f"{name}.{c}"] for c in columns})
+
+    def get_dataframe(self, name: str, columns: Collection[str] = None) -> pd.DataFrame:
+        dataset = self.get_dataset(name, columns)
+        return dataset.single_dim.to_pandas()
+
+    def _to_be_checkpointed(self) -> dict[str, xr.Dataset]:
+        result = {}
+        for table_name, table_data in self._tree.subspaces_iter():
+            # any data elements that were created without a
+            # last_checkpoint attr get one now
+            for k, v in table_data.variables.items():
+                if "last_checkpoint" not in v.attrs:
+                    v.attrs["last_checkpoint"] = None
+            # collect everything not checkpointed
+            uncheckpointed = table_data.filter_by_attrs(last_checkpoint=None)
+            if uncheckpointed:
+                result[table_name] = uncheckpointed
+        return result
+
+    def _zarr_subdir(self, table_name, checkpoint_name):
+        return self.directory.joinpath(table_name, checkpoint_name).with_suffix(".zarr")
+
+    def _parquet_name(self, table_name, checkpoint_name):
+        return self.directory.joinpath(table_name, checkpoint_name).with_suffix(
+            ".parquet"
+        )
+
+    def make_checkpoint(self, checkpoint_name: str, overwrite=True):
+        if self._mode == "r":
+            raise ReadOnlyError
+        to_be_checkpointed = self._to_be_checkpointed()
+        new_checkpoint = {
+            "timestamp": timestamp(),
+            "tables": {},
+            "relationships": [],
+        }
+        # remove checkpoint name from ordered list if it already exists
+        while checkpoint_name in self._checkpoint_order:
+            self._checkpoint_order.remove(checkpoint_name)
+        # add checkpoint name at end ordered list
+        self._checkpoint_order.append(checkpoint_name)
+        for table_name, table_data in to_be_checkpointed.items():
+            if self._storage_format == "parquet" and len(table_data.dims) == 1:
+                target = self._parquet_name(table_name, checkpoint_name)
+                if overwrite and target.is_file():
+                    os.unlink(target)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                table_data.single_dim.to_parquet(str(target))
+            elif self._storage_format == "zarr" or (
+                self._storage_format == "parquet" and len(table_data.dims) > 1
+            ):
+                # zarr is used if ndim > 1
+                target = self._zarr_subdir(table_name, checkpoint_name)
+                if overwrite and target.is_dir():
+                    shutil.rmtree(target)
+                target.mkdir(parents=True, exist_ok=True)
+                table_data.to_zarr_with_attr(target)
+            elif self._storage_format == "hdf5":
+                raise NotImplementedError
+            else:
+                raise ValueError(
+                    f"cannot write with storage format {self._storage_format!r}"
+                )
+            self.update(table_name, table_data, last_checkpoint=checkpoint_name)
+        for table_name, table_data in self._tree.subspaces_iter():
+            inventory = {"data_vars": {}, "coords": {}}
+            for varname, vardata in table_data.items():
+                inventory["data_vars"][varname] = {
+                    "last_checkpoint": vardata.attrs.get("last_checkpoint", "MISSING"),
+                    "dtype": str(vardata.dtype),
+                }
+            for varname, vardata in table_data.coords.items():
+                _cp = checkpoint_name
+                # coords in every checkpoint with any content
+                if table_name not in to_be_checkpointed:
+                    _cp = vardata.attrs.get("last_checkpoint", "MISSING")
+                inventory["coords"][varname] = {
+                    "last_checkpoint": _cp,
+                    "dtype": str(vardata.dtype),
+                }
+            new_checkpoint["tables"][table_name] = inventory
+        for r in self._tree.list_relationships():
+            new_checkpoint["relationships"].append(r.to_dict())
+        self._checkpoints[checkpoint_name] = new_checkpoint
+        self._write_checkpoint(checkpoint_name, new_checkpoint)
+        self._write_metadata()
+
+    def _write_checkpoint(self, name, checkpoint):
+        if self._mode == "r":
+            raise ReadOnlyError
+        checkpoint_metadata_target = self.directory.joinpath(
+            self.checkpoint_subdir, f"{name}.yaml"
+        )
+        if checkpoint_metadata_target.exists():
+            n = 1
+            while checkpoint_metadata_target.with_suffix(f".{n}.yaml").exists():
+                n += 1
+            os.rename(
+                checkpoint_metadata_target,
+                checkpoint_metadata_target.with_suffix(f".{n}.yaml"),
+            )
+        checkpoint_metadata_target.parent.mkdir(parents=True, exist_ok=True)
+        with open(checkpoint_metadata_target, "w") as f:
+            yaml.safe_dump(checkpoint, f)
+
+    def _write_metadata(self):
+        if self._mode == "r":
+            raise ReadOnlyError
+        metadata_target = self.directory.joinpath(self.metadata_filename)
+        if metadata_target.exists():
+            n = 1
+            while metadata_target.with_suffix(f".{n}.yaml").exists():
+                n += 1
+            os.rename(metadata_target, metadata_target.with_suffix(f".{n}.yaml"))
+        with open(metadata_target, "w") as f:
+            metadata = dict(
+                datastore_format_version=1,
+                checkpoint_order=self._checkpoint_order,
+            )
+            yaml.safe_dump(metadata, f)
+
+    def read_metadata(self, checkpoints=None):
+        """
+        Read storage metadata
+
+        Parameters
+        ----------
+        checkpoints : str | list[str], optional
+            Read only these checkpoints.  If not provided, only the latest
+            checkpoint metadata is read. Set to "*" to read all.
+        """
+        with open(self.directory.joinpath(self.metadata_filename), "r") as f:
+            metadata = yaml.safe_load(f)
+        datastore_format_version = metadata.get("datastore_format_version", "missing")
+        if datastore_format_version == 1:
+            self._checkpoint_order = metadata["checkpoint_order"]
+        else:
+            raise NotImplementedError(f"{datastore_format_version=}")
+        if checkpoints is None or checkpoints == self.LATEST:
+            checkpoints = [self._checkpoint_order[-1]]
+        elif isinstance(checkpoints, str):
+            if checkpoints == "*":
+                checkpoints = list(self._checkpoint_order)
+            else:
+                checkpoints = [checkpoints]
+        for c in checkpoints:
+            with open(
+                self.directory.joinpath(self.checkpoint_subdir, f"{c}.yaml"), "r"
+            ) as f:
+                self._checkpoints[c] = yaml.safe_load(f)
+
+    def restore_checkpoint(self, checkpoint_name: str):
+        if checkpoint_name not in self._checkpoints:
+            try:
+                self.read_metadata(checkpoint_name)
+            except FileNotFoundError:
+                raise KeyError(checkpoint_name)
+        checkpoint = self._checkpoints[checkpoint_name]
+        self._tree = DataTree(root_node_name=False)
+        for table_name, table_def in checkpoint["tables"].items():
+            if table_name == "timestamp":
+                continue
+            t = xr.Dataset()
+            opened_targets = {}
+            coords = table_def.get("coords", {})
+            if len(coords) == 1:
+                index_name = list(coords)[0]
+            else:
+                index_name = None
+            for coord_name, coord_def in coords.items():
+                target = self._zarr_subdir(table_name, coord_def["last_checkpoint"])
+                if target.exists():
+                    if target not in opened_targets:
+                        opened_targets[target] = from_zarr_with_attr(target)
+                else:
+                    # zarr not found, try parquet
+                    target2 = self._parquet_name(
+                        table_name, coord_def["last_checkpoint"]
+                    )
+                    if target2.exists():
+                        if target not in opened_targets:
+                            opened_targets[target] = _read_parquet(target2, index_name)
+                    else:
+                        raise FileNotFoundError(target)
+                t = t.assign_coords({coord_name: opened_targets[target][coord_name]})
+            data_vars = table_def.get("data_vars", {})
+            for var_name, var_def in data_vars.items():
+                if var_def["last_checkpoint"] == "MISSING":
+                    raise ValueError(f"missing checkpoint for {table_name}.{var_name}")
+                target = self._zarr_subdir(table_name, var_def["last_checkpoint"])
+                if target.exists():
+                    if target not in opened_targets:
+                        opened_targets[target] = from_zarr_with_attr(target)
+                else:
+                    # zarr not found, try parquet
+                    target2 = self._parquet_name(table_name, var_def["last_checkpoint"])
+                    if target2.exists():
+                        if target not in opened_targets:
+                            opened_targets[target] = _read_parquet(target2, index_name)
+                    else:
+                        raise FileNotFoundError(target)
+                t = t.assign({var_name: opened_targets[target][var_name]})
+            self._tree.add_dataset(table_name, t)
+        for r in checkpoint["relationships"]:
+            self._tree.add_relationship(Relationship(**r))
+
+    def add_relationship(self, relationship: str | Relationship):
+        self._tree.add_relationship(relationship)
+
+    def digitize_relationships(self, redigitize=True):
+        """
+        Convert all label-based relationships into position-based.
+
+        Parameters
+        ----------
+        redigitize : bool, default True
+            Re-compute position-based relationships from labels, even
+            if the relationship had previously been digitized.
+        """
+        self._keep_digitized = True
+        self._tree.digitize_relationships(inplace=True, redigitize=redigitize)
+
+    @property
+    def relationships_are_digitized(self) -> bool:
+        """bool : Whether all relationships are digital (by position)."""
+        return self._tree.relationships_are_digitized

--- a/sharrow/datastore.py
+++ b/sharrow/datastore.py
@@ -204,7 +204,7 @@ class DataStore:
         for table_name, table_data in self._tree.subspaces_iter():
             # any data elements that were created without a
             # last_checkpoint attr get one now
-            for k, v in table_data.variables.items():
+            for _k, v in table_data.variables.items():
                 if "last_checkpoint" not in v.attrs:
                     v.attrs["last_checkpoint"] = None
             # collect everything not checkpointed
@@ -350,7 +350,7 @@ class DataStore:
             try:
                 self.read_metadata(checkpoint_name)
             except FileNotFoundError:
-                raise KeyError(checkpoint_name)
+                raise KeyError(checkpoint_name) from None
         checkpoint = self._checkpoints[checkpoint_name]
         self._tree = DataTree(root_node_name=False)
         for table_name, table_def in checkpoint["tables"].items():

--- a/sharrow/datastore.py
+++ b/sharrow/datastore.py
@@ -385,7 +385,7 @@ class DataStore:
             Read only these checkpoints.  If not provided, only the latest
             checkpoint metadata is read. Set to "*" to read all.
         """
-        with open(self.directory.joinpath(self.metadata_filename), "r") as f:
+        with open(self.directory.joinpath(self.metadata_filename)) as f:
             metadata = yaml.safe_load(f)
         datastore_format_version = metadata.get("datastore_format_version", "missing")
         if datastore_format_version == 1:
@@ -401,7 +401,7 @@ class DataStore:
                 checkpoints = [checkpoints]
         for c in checkpoints:
             with open(
-                self.directory.joinpath(self.checkpoint_subdir, f"{c}.yaml"), "r"
+                self.directory.joinpath(self.checkpoint_subdir, f"{c}.yaml")
             ) as f:
                 self._checkpoints[c] = yaml.safe_load(f)
 

--- a/sharrow/digital_encoding.py
+++ b/sharrow/digital_encoding.py
@@ -163,24 +163,35 @@ def find_bins(values, final_width=255):
 def digitize_by_dictionary(arr, bitwidth=8):
     result = arr.copy()
     bins = find_bins(arr, final_width=1 << bitwidth)
-    bin_edges = (bins[1:] - bins[:-1]) / 2 + bins[:-1]
     try:
-        arr_data = arr.data
-    except AttributeError:
-        pass
+        bin_edges = (bins[1:] - bins[:-1]) / 2 + bins[:-1]
+    except TypeError:
+        # bins are not numeric
+        bin_map = {x:n for n,x in enumerate(bins)}
+        u, inv = np.unique(arr.data, return_inverse=True)
+        result.data = np.array([bin_map.get(x) for x in u])[inv].reshape(arr.shape)
+        result.attrs["digital_encoding"] = {
+            "dictionary": bins,
+        }
+        return result
     else:
-        if isinstance(arr_data, da.Array):
-            result.data = da.digitize(arr_data, bin_edges).astype(f"uint{bitwidth}")
-            result.attrs["digital_encoding"] = {
-                "dictionary": bins,
-            }
-            return result
-    # fall back to numpy digitize
-    result.data = np.digitize(arr, bin_edges).astype(f"uint{bitwidth}")
-    result.attrs["digital_encoding"] = {
-        "dictionary": bins,
-    }
-    return result
+        try:
+            arr_data = arr.data
+        except AttributeError:
+            pass
+        else:
+            if isinstance(arr_data, da.Array):
+                result.data = da.digitize(arr_data, bin_edges).astype(f"uint{bitwidth}")
+                result.attrs["digital_encoding"] = {
+                    "dictionary": bins,
+                }
+                return result
+        # fall back to numpy digitize
+        result.data = np.digitize(arr, bin_edges).astype(f"uint{bitwidth}")
+        result.attrs["digital_encoding"] = {
+            "dictionary": bins,
+        }
+        return result
 
 
 @xr.register_dataset_accessor("digital_encoding")

--- a/sharrow/filewrite.py
+++ b/sharrow/filewrite.py
@@ -21,7 +21,7 @@ def blacken(code):
     except Exception as err:
         import warnings
 
-        warnings.warn(f"error in blacken: {err!r}")
+        warnings.warn(f"error in blacken: {err!r}", stacklevel=2)
         return code
 
 

--- a/sharrow/flows.py
+++ b/sharrow/flows.py
@@ -1575,7 +1575,7 @@ class Flow:
         # if an existing __init__ file matches the hash, just use it
         init_file = os.path.join(self.cache_dir, self.name, "__init__.py")
         if os.path.isfile(init_file):
-            with open(init_file, "rt") as f:
+            with open(init_file) as f:
                 content = f.read()
             s = re.search("""flow_hash = ['"](.*)['"]""", content)
         else:
@@ -2802,7 +2802,7 @@ class Flow:
         from pygments.lexers.python import PythonLexer
 
         codefile = os.path.join(self.cache_dir, self.name, "__init__.py")
-        with open(codefile, "rt") as f_code:
+        with open(codefile) as f_code:
             code = f_code.read()
         pretty = highlight(code, PythonLexer(), HtmlFormatter(linenos=linenos))
         css = HtmlFormatter().get_style_defs(".highlight")

--- a/sharrow/flows.py
+++ b/sharrow/flows.py
@@ -208,7 +208,13 @@ def coerce_to_range_index(idx):
 FUNCTION_TEMPLATE = """
 
 # {init_expr}
-@nb.jit(cache=False, error_model='{error_model}', boundscheck={boundscheck}, nopython={nopython}, fastmath={fastmath}, nogil={nopython})
+@nb.jit(
+    cache=False,
+    error_model='{error_model}',
+    boundscheck={boundscheck},
+    nopython={nopython},
+    fastmath={fastmath},
+    nogil={nopython})
 def {fname}(
     {argtokens}
     _outputs,
@@ -220,7 +226,14 @@ def {fname}(
 
 
 IRUNNER_1D_TEMPLATE = """
-@nb.jit(cache=True, parallel=True, error_model='{error_model}', boundscheck={boundscheck}, nopython={nopython}, fastmath={fastmath}, nogil={nopython})
+@nb.jit(
+    cache=True,
+    parallel=True,
+    error_model='{error_model}',
+    boundscheck={boundscheck},
+    nopython={nopython},
+    fastmath={fastmath},
+    nogil={nopython})
 def irunner(
     argshape,
     {joined_namespace_names}
@@ -241,7 +254,14 @@ def irunner(
 """
 
 IRUNNER_2D_TEMPLATE = """
-@nb.jit(cache=True, parallel=True, error_model='{error_model}', boundscheck={boundscheck}, nopython={nopython}, fastmath={fastmath}, nogil={nopython})
+@nb.jit(
+    cache=True,
+    parallel=True,
+    error_model='{error_model}',
+    boundscheck={boundscheck},
+    nopython={nopython},
+    fastmath={fastmath},
+    nogil={nopython})
 def irunner(
     argshape,
     {joined_namespace_names}
@@ -263,7 +283,14 @@ def irunner(
 """
 
 IDOTTER_1D_TEMPLATE = """
-@nb.jit(cache=True, parallel=True, error_model='{error_model}', boundscheck={boundscheck}, nopython={nopython}, fastmath={fastmath}, nogil={nopython})
+@nb.jit(
+    cache=True,
+    parallel=True,
+    error_model='{error_model}',
+    boundscheck={boundscheck},
+    nopython={nopython},
+    fastmath={fastmath},
+    nogil={nopython})
 def idotter(
     argshape,
     {joined_namespace_names}
@@ -288,7 +315,14 @@ def idotter(
 """
 
 IDOTTER_2D_TEMPLATE = """
-@nb.jit(cache=True, parallel=True, error_model='{error_model}', boundscheck={boundscheck}, nopython={nopython}, fastmath={fastmath}, nogil={nopython})
+@nb.jit(
+    cache=True,
+    parallel=True,
+    error_model='{error_model}',
+    boundscheck={boundscheck},
+    nopython={nopython},
+    fastmath={fastmath},
+    nogil={nopython})
 def idotter(
     argshape,
     {joined_namespace_names}
@@ -315,7 +349,13 @@ def idotter(
 """
 
 ILINER_1D_TEMPLATE = """
-@nb.jit(cache=False, error_model='{error_model}', boundscheck={boundscheck}, nopython={nopython}, fastmath={fastmath}, nogil={nopython})
+@nb.jit(
+    cache=False,
+    error_model='{error_model}',
+    boundscheck={boundscheck},
+    nopython={nopython},
+    fastmath={fastmath},
+    nogil={nopython})
 def linemaker(
     intermediate, j0,
     {joined_namespace_names}
@@ -325,7 +365,13 @@ def linemaker(
 """
 
 ILINER_2D_TEMPLATE = """
-@nb.jit(cache=False, error_model='{error_model}', boundscheck={boundscheck}, nopython={nopython}, fastmath={fastmath}, nogil={nopython})
+@nb.jit(
+    cache=False,
+    error_model='{error_model}',
+    boundscheck={boundscheck},
+    nopython={nopython},
+    fastmath={fastmath},
+    nogil={nopython})
 def linemaker(
     intermediate, j0, j1,
     {joined_namespace_names}
@@ -336,7 +382,13 @@ def linemaker(
 
 
 MNL_GENERIC_TEMPLATE = """
-@nb.jit(cache=True, error_model='{error_model}', boundscheck={boundscheck}, nopython={nopython}, fastmath={fastmath}, nogil={nopython})
+@nb.jit(
+    cache=True,
+    error_model='{error_model}',
+    boundscheck={boundscheck},
+    nopython={nopython},
+    fastmath={fastmath},
+    nogil={nopython})
 def _sample_choices_maker(
         prob_array,
         random_array,
@@ -386,7 +438,13 @@ def _sample_choices_maker(
 
 
 
-@nb.jit(cache=True, error_model='{error_model}', boundscheck={boundscheck}, nopython={nopython}, fastmath={fastmath}, nogil={nopython})
+@nb.jit(
+    cache=True,
+    error_model='{error_model}',
+    boundscheck={boundscheck},
+    nopython={nopython},
+    fastmath={fastmath},
+    nogil={nopython})
 def _sample_choices_maker_counted(
         prob_array,
         random_array,
@@ -451,7 +509,14 @@ MNL_1D_TEMPLATE = (
 
 logit_ndims = 1
 
-@nb.jit(cache=True, parallel=True, error_model='{error_model}', boundscheck={boundscheck}, nopython={nopython}, fastmath={fastmath}, nogil={nopython})
+@nb.jit(
+    cache=True,
+    parallel=True,
+    error_model='{error_model}',
+    boundscheck={boundscheck},
+    nopython={nopython},
+    fastmath={fastmath},
+    nogil={nopython})
 def mnl_transform_plus1d(
     argshape,
     {joined_namespace_names}
@@ -501,7 +566,13 @@ def mnl_transform_plus1d(
 
 """
 )
-# @nb.jit(cache=True, parallel=True, error_model='{error_model}', boundscheck={boundscheck}, nopython={nopython}, fastmath={fastmath})
+# @nb.jit(
+#     cache=True,
+#     parallel=True,
+#     error_model='{error_model}',
+#     boundscheck={boundscheck},
+#     nopython={nopython},
+#     fastmath={fastmath})
 # def mnl_transform_plus1d(
 #     argshape,
 #     {joined_namespace_names}
@@ -538,7 +609,9 @@ def mnl_transform_plus1d(
 #             if logsums:
 #                 _logsums[j0,k0] = np.log(local_sum) + shifter
 #             if pick_counted:
-#                 _sample_choices_maker_counted(partial, random_draws[j0,k0], result[j0,k0], result_p[j0,k0], pick_count[j0,k0])
+#                 _sample_choices_maker_counted(
+#                   partial, random_draws[j0,k0], result[j0,k0], result_p[j0,k0], pick_count[j0,k0]
+#                 )
 #             else:
 #                 _sample_choices_maker(partial, random_draws[j0,k0], result[j0,k0], result_p[j0,k0])
 #     return result, result_p, pick_count, _logsums
@@ -550,7 +623,14 @@ MNL_2D_TEMPLATE = (
 
 logit_ndims = 2
 
-@nb.jit(cache=True, parallel=True, error_model='{error_model}', boundscheck={boundscheck}, nopython={nopython}, fastmath={fastmath}, nogil={nopython})
+@nb.jit(
+    cache=True,
+    parallel=True,
+    error_model='{error_model}',
+    boundscheck={boundscheck},
+    nopython={nopython},
+    fastmath={fastmath},
+    nogil={nopython})
 def mnl_transform(
     argshape,
     {joined_namespace_names}
@@ -614,7 +694,14 @@ def mnl_transform(
     return result, result_p, pick_count, _logsums
 
 
-@nb.jit(cache=True, parallel=True, error_model='{error_model}', boundscheck={boundscheck}, nopython={nopython}, fastmath={fastmath}, nogil={nopython})
+@nb.jit(
+    cache=True,
+    parallel=True,
+    error_model='{error_model}',
+    boundscheck={boundscheck},
+    nopython={nopython},
+    fastmath={fastmath},
+    nogil={nopython})
 def mnl_transform_plus1d(
     argshape,
     {joined_namespace_names}
@@ -669,7 +756,9 @@ def mnl_transform_plus1d(
                     continue
             partial /= local_sum
             if pick_counted:
-                _sample_choices_maker_counted(partial, random_draws[j0,j1], result[j0,j1], result_p[j0,j1], pick_count[j0,j1])
+                _sample_choices_maker_counted(
+                    partial, random_draws[j0,j1], result[j0,j1], result_p[j0,j1], pick_count[j0,j1]
+                )
             else:
                 _sample_choices_maker(partial, random_draws[j0,j1], result[j0,j1], result_p[j0,j1])
     return result, result_p, pick_count, _logsums
@@ -681,7 +770,14 @@ NL_1D_TEMPLATE = """
 
 from sharrow.nested_logit import _utility_to_probability
 
-@nb.jit(cache=True, parallel=True, error_model='{error_model}', boundscheck={boundscheck}, nopython={nopython}, fastmath={fastmath}, nogil={nopython})
+@nb.jit(
+    cache=True,
+    parallel=True,
+    error_model='{error_model}',
+    boundscheck={boundscheck},
+    nopython={nopython},
+    fastmath={fastmath},
+    nogil={nopython})
 def nl_transform(
     argshape,
     {joined_namespace_names}
@@ -751,7 +847,9 @@ def nl_transform(
                 _logsums[j0] = utility[-1]
             if logsums != 1:
                 if pick_counted:
-                    _sample_choices_maker_counted(probability[:n_alts], random_draws[j0], result[j0], result_p[j0], pick_count[j0])
+                    _sample_choices_maker_counted(
+                        probability[:n_alts], random_draws[j0], result[j0], result_p[j0], pick_count[j0]
+                    )
                 else:
                     _sample_choices_maker(probability[:n_alts], random_draws[j0], result[j0], result_p[j0])
     return result, result_p, pick_count, _logsums
@@ -945,7 +1043,7 @@ class Flow:
 
         all_raw_names = set()
         all_name_tokens = set()
-        for k, expr in defs.items():
+        for _k, expr in defs.items():
             plain_names, attribute_pairs, subscript_pairs = extract_names_2(expr)
             all_raw_names |= plain_names
             if self.tree.root_node_name:
@@ -1182,7 +1280,7 @@ class Flow:
                 other_way = False
                 # if other_way is triggered, there may be residual other terms
                 # that were not addressed, so this loop should be applied again.
-                for spacename, spacearrays in self.tree.subspaces.items():
+                for spacename in self.tree.subspaces.keys():
                     dim_slots, digital_encodings, blenders = meta_data[spacename]
                     try:
                         expr = expression_for_numba(
@@ -1779,7 +1877,9 @@ class Flow:
             assembled_args = [args.get(k) for k in self.arg_name_positions.keys()]
             for aa in assembled_args:
                 if aa.dtype.kind != "i":
-                    warnings.warn("position arguments are not all integers")
+                    warnings.warn(
+                        "position arguments are not all integers", stacklevel=2
+                    )
             try:
                 if runner is None:
                     if dot is None:
@@ -2078,7 +2178,9 @@ class Flow:
                             f"cache miss in {self.flow_hash}{warning_text}\n"
                             f"Compile Time: {timers}"
                         )
-                        warnings.warn(f"{self.flow_hash}", CacheMissWarning)
+                        warnings.warn(
+                            f"{self.flow_hash}", CacheMissWarning, stacklevel=1
+                        )
                         self.compiled_recently = True
                         self._known_cache_misses[runner_name][k] = v
         return self.compiled_recently

--- a/sharrow/nested_logit.py
+++ b/sharrow/nested_logit.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from collections.abc import Mapping
 
 import numba as nb
 import numpy as np

--- a/sharrow/relationships.py
+++ b/sharrow/relationships.py
@@ -47,6 +47,8 @@ well_known_names = {
     "clip",
 }
 
+NOTSET = "<--NOTSET-->"
+
 
 def _require_string(x):
     if not isinstance(x, str):
@@ -197,7 +199,15 @@ class Relationship:
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
-            return repr(self) == repr(other)
+            if self.analog:
+                left = f"<Relationship by label: {self.parent_data}[{self.analog!r}] -> {self.child_data}[{self.child_name!r}]>"
+            else:
+                left = repr(self)
+            if other.analog:
+                right = f"<Relationship by label: {other.parent_data}[{other.analog!r}] -> {other.child_data}[{other.child_name!r}]>"
+            else:
+                right = repr(other)
+            return left == right
 
     def __repr__(self):
         return f"<Relationship by {self.indexing}: {self.parent_data}[{self.parent_name!r}] -> {self.child_data}[{self.child_name!r}]>"
@@ -207,6 +217,16 @@ class Relationship:
             parent_name=self.parent_name,
             child_name=self.child_name,
             indexing=self.indexing,
+        )
+
+    def to_dict(self):
+        return dict(
+            parent_data=self.parent_data,
+            parent_name=self.parent_name,
+            child_data=self.child_data,
+            child_name=self.child_name,
+            indexing=self.indexing,
+            analog=self.analog,
         )
 
     @classmethod
@@ -257,7 +277,7 @@ class DataTree:
     Parameters
     ----------
     graph : networkx.MultiDiGraph
-    root_node_name : str
+    root_node_name : str or False
         The name of the node at the root of the tree.
     extra_funcs : Tuple[Callable]
         Additional functions that can be called by Flow objects created
@@ -441,14 +461,33 @@ class DataTree:
 
     @root_node_name.setter
     def root_node_name(self, name):
-        if name is None:
-            self._root_node_name = None
+        if name is None or name is False:
+            self._root_node_name = name
             return
         if not isinstance(name, str):
-            raise TypeError(f"root_node_name must be str not {type(name)}")
+            raise TypeError(
+                f"root_node_name must be one of [str, None, False] not {type(name)}"
+            )
         if name not in self._graph.nodes:
             raise KeyError(name)
         self._root_node_name = name
+
+    @property
+    def root_node_name_str(self):
+        """str: The root node for this data tree, which is only ever a parent.
+
+        This method raises a ValueError if root node cannot be determined.
+        """
+        if self._root_node_name is None:
+            for nodename in self._graph.nodes:
+                if self._graph.in_degree(nodename) == 0:
+                    self._root_node_name = nodename
+                    break
+        if self._root_node_name is None:
+            raise ValueError("root node cannot be determined")
+        if self._root_node_name is False:
+            raise ValueError("root node is False")
+        return self._root_node_name
 
     def add_relationship(self, *args, **kwargs):
         """
@@ -469,28 +508,7 @@ class DataTree:
         if len(args) == 1 and isinstance(args[0], Relationship):
             r = args[0]
         elif len(args) == 1 and isinstance(args[0], str):
-            s = args[0]
-            if "->" in s:
-                parent, child = s.split("->", 1)
-                i = "position"
-            elif "@" in s:
-                parent, child = s.split("@", 1)
-                i = "label"
-            else:
-                raise ValueError(f"cannot interpret relationship {s!r}")
-            p1, p2 = parent.split(".", 1)
-            c1, c2 = child.split(".", 1)
-            p1 = p1.strip()
-            p2 = p2.strip()
-            c1 = c1.strip()
-            c2 = c2.strip()
-            r = Relationship(
-                parent_data=p1,
-                parent_name=p2,
-                child_data=c1,
-                child_name=c2,
-                indexing=i,
-            )
+            r = Relationship.from_string(args[0])
         else:
             r = Relationship(*args, **kwargs)
 
@@ -510,6 +528,13 @@ class DataTree:
     def get_relationship(self, parent, child):
         attrs = self._graph.edges[parent, child]
         return Relationship(parent_data=parent, child_data=child, **attrs)
+
+    def list_relationships(self) -> list[Relationship]:
+        """list : List all relationships defined in this tree."""
+        result = []
+        for e in self._graph.edges:
+            result.append(self._get_relationship(e))
+        return result
 
     def add_dataset(self, name, dataset, relationships=(), as_root=False):
         """
@@ -564,11 +589,11 @@ class DataTree:
 
     @property
     def root_node(self):
-        return self._graph.nodes[self.root_node_name]
+        return self._graph.nodes[self.root_node_name_str]
 
     @property
     def root_dataset(self):
-        return self._graph.nodes[self.root_node_name]["dataset"]
+        return self._graph.nodes[self.root_node_name_str]["dataset"]
 
     @root_dataset.setter
     def root_dataset(self, x):
@@ -576,7 +601,7 @@ class DataTree:
 
         if not isinstance(x, Dataset):
             x = construct(x)
-        if self.root_node_name in self.replacement_filters:
+        if self.root_node_name_str in self.replacement_filters:
             x = self.replacement_filters[self.root_node_name](x)
         self._graph.nodes[self.root_node_name]["dataset"] = x
 
@@ -630,16 +655,28 @@ class DataTree:
                     raise
                 else:
                     result = xr.DataArray(default)
-        root_dataset = self.root_dataset
-        if result.dims != self.root_dims and broadcast:
-            result, _ = xr.broadcast(result, root_dataset)
-        if coords:
-            add_coords = {}
-            for i in result.dims:
-                if i not in result.coords and i in root_dataset.coords:
-                    add_coords[i] = root_dataset.coords[i]
-            if add_coords:
-                result = result.assign_coords(add_coords)
+        if self.root_node_name:
+            root_dataset = self.root_dataset
+            if result.dims != self.root_dims and broadcast:
+                result, _ = xr.broadcast(result, root_dataset)
+            if coords:
+                add_coords = {}
+                for i in result.dims:
+                    if i not in result.coords and i in root_dataset.coords:
+                        add_coords[i] = root_dataset.coords[i]
+                if add_coords:
+                    result = result.assign_coords(add_coords)
+        elif self.root_node_name is False:
+            if "." in item:
+                item_in, item = item.split(".", 1)
+                base_dataset = self._graph.nodes[item_in]["dataset"]
+                if coords:
+                    add_coords = {}
+                    for i in result.dims:
+                        if i not in result.coords and i in base_dataset.coords:
+                            add_coords[i] = base_dataset.coords[i]
+                    if add_coords:
+                        result = result.assign_coords(add_coords)
         return result
 
     def finditem(self, item, maybe_in=None):
@@ -665,11 +702,17 @@ class DataTree:
 
         if "." in item:
             item_in, item = item.split(".", 1)
+            queue = [self.root_node_name]
+            if self.root_node_name is False:
+                # when root_node_name is False, we don't want to broadcast
+                # back to the root, but instead only to the given `item_in`
+                queue = [item_in]
+                item_in = None
         else:
             item_in = None
-
-        queue = [self.root_node_name]
+            queue = [self.root_node_name_str]
         examined = set()
+        start_from = queue[0]
         while len(queue):
             current_node = queue.pop(0)
             if current_node in examined:
@@ -686,7 +729,7 @@ class DataTree:
             if (by_name or by_dims) and (item_in is None or item_in == current_node):
                 if just_node_name:
                     return current_node
-                if current_node == self.root_node_name:
+                if current_node == start_from:
                     if by_dims:
                         return xr.DataArray(
                             pd.RangeIndex(dataset.dims[item]), dims=item
@@ -711,19 +754,19 @@ class DataTree:
                     dims_in_result = set(result.dims)
                     top_dim_names = {}
                     for path in nx.algorithms.simple_paths.all_simple_edge_paths(
-                        self._graph, self.root_node_name, current_node
+                        self._graph, start_from, current_node
                     ):
                         if dim_names_from_top:
                             e = path[0]
                             top_dim_name = self._graph.edges[e].get("parent_name")
-                            root_dataset = self.root_dataset
+                            start_dataset = self._graph.nodes[start_from]["dataset"]
                             # deconvert digitized dim names back to native dims
                             if (
-                                top_dim_name not in root_dataset.dims
-                                and top_dim_name in root_dataset.variables
+                                top_dim_name not in start_dataset.dims
+                                and top_dim_name in start_dataset.variables
                             ):
-                                if root_dataset.variables[top_dim_name].ndim == 1:
-                                    top_dim_name = root_dataset.variables[
+                                if start_dataset.variables[top_dim_name].ndim == 1:
+                                    top_dim_name = start_dataset.variables[
                                         top_dim_name
                                     ].dims[0]
                         else:
@@ -828,6 +871,8 @@ class DataTree:
                 result = DataArray(
                     pd.eval(expression, resolvers=[self], engine="numexpr"),
                 )
+            else:
+                raise ValueError(f"unknown engine {engine}")
         return result
 
     @property
@@ -845,6 +890,42 @@ class DataTree:
             s = self._graph.nodes[k].get("dataset", None)
             if s is not None:
                 yield (k, s)
+
+    def contains_subspace(self, key) -> bool:
+        """
+        Is this named Dataset in this tree's subspaces
+
+        Parameters
+        ----------
+        key : str
+
+        Returns
+        -------
+        bool
+        """
+        return key in self._graph.nodes
+
+    def get_subspace(self, key, default_empty=False) -> xr.Dataset:
+        """
+        Access named Dataset from this tree's subspaces
+
+        Parameters
+        ----------
+        key : str
+        default_empty : bool, default False
+            Return an empty Dataset if the key is not found.
+
+        Returns
+        -------
+        xr.Dataset
+        """
+        result = self._graph.nodes[key].get("dataset", None)
+        if result is None:
+            if default_empty:
+                result = xr.Dataset()
+            else:
+                raise KeyError(key)
+        return result
 
     def namespace_names(self):
         namespace = set()
@@ -1074,6 +1155,7 @@ class DataTree:
         write_hash_audit=True,
         hashing_level=1,
         dim_exclude=None,
+        with_root_node_name=None,
     ):
         """
         Set up a new Flow for analysis using the structure of this DataTree.
@@ -1158,6 +1240,7 @@ class DataTree:
             write_hash_audit=write_hash_audit,
             dim_order=self.dim_order,
             dim_exclude=dim_exclude,
+            with_root_node_name=with_root_node_name,
         )
 
     def _spill(self, all_name_tokens=()):
@@ -1237,8 +1320,9 @@ class DataTree:
 
                 # vectorize version
                 mapper = {i: j for (j, i) in enumerate(_dataarray_to_numpy(downstream))}
+                mapper_get = lambda x: mapper.get(x, 0)
                 if upstream.size:
-                    offsets = xr.apply_ufunc(np.vectorize(mapper.get), upstream)
+                    offsets = xr.apply_ufunc(np.vectorize(mapper_get), upstream)
                 else:
                     offsets = xr.DataArray([], dims=["index"])
                 if offsets.dtype.kind != "i":
@@ -1353,29 +1437,40 @@ class DataTree:
                 try:
                     upside = ", ".join(unparse(t) for t in upside_ast)
                 except:  # noqa: E722
-                    for t in upside_ast:
-                        str_t = str(t)
-                        if len(str_t) < 2000:
-                            print(f"t:{str_t}")
-                        else:
-                            print(f"t:{str_t[:200]}...")
-                    raise
-
-                # check for redirection target
-                if retarget is not None:
-                    tokens.append(
-                        f"__{spacename}___digitized_{retarget}_of_{this_dim_name}[__{parent_data}__{parent_name}[{upside}]]"
-                    )
-                else:
-                    tokens.append(f"__{parent_data}__{parent_name}[{upside}]")
+                    if self.root_node_name is False:
+                        upside = None
+                    else:
+                        print(f"{parent_data=}")
+                        print(f"{parent_name=}")
+                        print(f"{spacearrayname=}")
+                        print(f"{exclude_dims=}")
+                        print(f"{blends=}")
+                        for t in upside_ast:
+                            str_t = str(t)
+                            if len(str_t) < 2000:
+                                print(f"t:{str_t}")
+                            else:
+                                print(f"t:{str_t[:200]}...")
+                        raise
+                if upside is not None:
+                    # check for redirection target
+                    if retarget is not None:
+                        tokens.append(
+                            f"__{spacename}___digitized_{retarget}_of_{this_dim_name}[__{parent_data}__{parent_name}[{upside}]]"
+                        )
+                    else:
+                        tokens.append(f"__{parent_data}__{parent_name}[{upside}]")
                 found_token = True
                 break
             if not found_token:
                 if dimname in self.subspaces[spacename].indexes:
-                    ix = self.subspaces[spacename].indexes[dimname]
-                    ix = {i: n for n, i in enumerate(ix)}
-                    tokens.append(ix)
-                    n_missing_tokens += 1
+                    if self.root_node_name is False:
+                        tokens.append(False)
+                    else:
+                        ix = self.subspaces[spacename].indexes[dimname]
+                        ix = {i: n for n, i in enumerate(ix)}
+                        tokens.append(ix)
+                        n_missing_tokens += 1
                 elif dimname.endswith("_indices") or dimname.endswith("_indptr"):
                     tokens.append(None)
                     # this dimension corresponds to a blender

--- a/sharrow/shared_memory.py
+++ b/sharrow/shared_memory.py
@@ -99,7 +99,7 @@ def create_shared_memory_array(key, size):
                 size=size,
             )
         except FileExistsError:
-            raise FileExistsError(f"sharrow_shared_memory_array:{key}")
+            raise FileExistsError(f"sharrow_shared_memory_array:{key}") from None
         __GLOBAL_MEMORY_ARRAYS[key] = result
         return result
 
@@ -138,7 +138,7 @@ def open_shared_memory_array(key, mode="r+"):
                 create=False,
             )
         except FileNotFoundError:
-            raise FileNotFoundError(f"sharrow_shared_memory_array:{key}")
+            raise FileNotFoundError(f"sharrow_shared_memory_array:{key}") from None
         else:
             logger.info(
                 f"shared memory array from ephemeral memory, {si_units(result.size)}"
@@ -175,7 +175,7 @@ def create_shared_list(content, key):
                 name=h,
             )
         except FileExistsError:
-            raise FileExistsError(f"sharrow_shared_memory_list:{key}")
+            raise FileExistsError(f"sharrow_shared_memory_list:{key}") from None
         __GLOBAL_MEMORY_LISTS[key] = result
         return result
 
@@ -190,7 +190,7 @@ def read_shared_list(key):
         try:
             sl = ShareableList(name=_hexhash(f"sharrow__list__{key}"))
         except FileNotFoundError:
-            raise FileNotFoundError(f"sharrow_shared_memory_list:{key}")
+            raise FileNotFoundError(f"sharrow_shared_memory_list:{key}") from None
         else:
             return sl
 
@@ -202,7 +202,7 @@ def get_shared_list_nbytes(key):
     try:
         shm = SharedMemory(name=h, create=False)
     except FileNotFoundError:
-        raise FileNotFoundError(f"sharrow_shared_memory_list:{key}")
+        raise FileNotFoundError(f"sharrow_shared_memory_list:{key}") from None
     else:
         return shm.size
 
@@ -397,7 +397,7 @@ class SharedMemDatasetAccessor:
         try:
             return self._shared_memory_key_
         except AttributeError:
-            raise ValueError("this dataset is not in shared memory")
+            raise ValueError("this dataset is not in shared memory") from None
 
     @classmethod
     def from_shared_memory(cls, key, own_data=False, mode="r+"):
@@ -431,7 +431,7 @@ class SharedMemDatasetAccessor:
             # for memmap, list is loaded from pickle, not shared ram
             pass
 
-        if own_data and not (own_data is True):
+        if own_data and own_data is not True:
             mem = own_data
             own_data = True
         else:
@@ -513,7 +513,7 @@ class SharedMemDatasetAccessor:
         try:
             return sum(i.size for i in self._shared_memory_objs_)
         except AttributeError:
-            raise ValueError("this dataset is not in shared memory")
+            raise ValueError("this dataset is not in shared memory") from None
 
     @property
     def is_shared_memory(self):

--- a/sharrow/table.py
+++ b/sharrow/table.py
@@ -257,7 +257,7 @@ class Table:
                 stopper = blockname
             else:
                 qlog = os.path.join(path, "quilt.log")
-                with open(qlog, "rt") as logreader:
+                with open(qlog) as logreader:
                     existing_info = yaml.safe_load(logreader)
                 for _stopper, block in enumerate(existing_info):
                     if block.get("name", None) == blockname:
@@ -296,7 +296,7 @@ class Table:
                 n += 1
         if builder is not None:
             metadata = builder.schema.metadata
-            metadata[b"quilt_number"] = f"{n}".encode("utf8")
+            metadata[b"quilt_number"] = f"{n}".encode()
             return builder.replace_schema_metadata(metadata)
         return None
 
@@ -310,7 +310,7 @@ class Table:
             ex_cols = []
             max_block = -1
         else:
-            with open(qlog, "rt") as logreader:
+            with open(qlog) as logreader:
                 existing_info = yaml.safe_load(logreader)
             ex_rows = sum(block.get("rows", 0) for block in existing_info)
             ex_cols = sum((block.get("cols", []) for block in existing_info), [])

--- a/sharrow/table.py
+++ b/sharrow/table.py
@@ -259,7 +259,7 @@ class Table:
                 qlog = os.path.join(path, "quilt.log")
                 with open(qlog, "rt") as logreader:
                     existing_info = yaml.safe_load(logreader)
-                for stopper, block in enumerate(existing_info):
+                for _stopper, block in enumerate(existing_info):
                     if block.get("name", None) == blockname:
                         break
                 else:
@@ -267,8 +267,13 @@ class Table:
         else:
             stopper = 1e99
         n = 0
-        rowfile = lambda n: os.path.join(path, f"block.{n:03d}.rows")
-        colfile = lambda n: os.path.join(path, f"block.{n:03d}.cols")
+
+        def rowfile(n):
+            return os.path.join(path, f"block.{n:03d}.rows")
+
+        def colfile(n):
+            return os.path.join(path, f"block.{n:03d}.cols")
+
         builder = None
         look = True
         while look and n <= stopper:

--- a/sharrow/tests/conftest.py
+++ b/sharrow/tests/conftest.py
@@ -1,0 +1,53 @@
+import pytest
+import xarray as xr
+import pandas as pd
+from sharrow.dataset import construct
+
+
+@pytest.fixture
+def person_dataset() -> xr.Dataset:
+    """
+    Sample persons dataset with dummy data.
+    """
+    df = pd.DataFrame(
+        {
+            "Income": [45, 88, 56, 15, 71],
+            "Name": ["Andre", "Bruce", "Carol", "David", "Eugene"],
+            "Age": [14, 25, 55, 8, 21],
+            "WorkMode": ["Car", "Bus", "Car", "Car", "Walk"],
+            "household_id": [11, 11, 22, 22, 33],
+        },
+        index=pd.Index([441, 445, 552, 556, 934], name="person_id"),
+    )
+    df["WorkMode"] = df["WorkMode"].astype("category")
+    return construct(df)
+
+
+@pytest.fixture
+def household_dataset() -> xr.Dataset:
+    """
+    Sample household dataset with dummy data.
+    """
+    df = pd.DataFrame(
+        {
+            "n_cars": [1, 2, 1],
+        },
+        index=pd.Index([11, 22, 33], name="household_id"),
+    )
+    return construct(df)
+
+
+@pytest.fixture
+def tours_dataset() -> xr.Dataset:
+    """
+    Sample tours dataset with dummy data.
+    """
+    df = pd.DataFrame(
+        {
+            "TourMode": ["Car", "Bus", "Car", "Car", "Walk"],
+            "person_id": [441, 445, 552, 556, 934],
+        },
+        index=pd.Index([4411, 4451, 5521, 5561, 9341], name="tour_id"),
+    )
+    df["TourMode"] = df["TourMode"].astype("category")
+    return construct(df)

--- a/sharrow/tests/test_categorical.py
+++ b/sharrow/tests/test_categorical.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+import os
+import numpy as np
+
+import pandas as pd
+import pytest
+import xarray as xr
+
+import sharrow
+from sharrow.dataset import construct
+
+
+
+def test_simple_cat(
+    tours_dataset: xr.Dataset
+):
+
+    tree = sharrow.DataTree(tours=tours_dataset)
+
+    assert all(tours_dataset.TourMode.cat.categories == ['Bus', 'Car', 'Walk'])
+
+    expr = "tours.TourMode == 'Bus'"
+    f = tree.setup_flow({expr:expr})
+    a = f.load_dataarray(dtype=np.int8)
+    a = a.isel(expressions=0)
+    assert all(a == np.asarray([0,1,0,0,0]))
+
+    tour_mode_bus = tree.get_expr(expr)
+    assert all(tour_mode_bus == np.asarray([0,1,0,0,0]))
+
+
+def test_2_level_tree_cat(
+    tours_dataset: xr.Dataset,
+    person_dataset: xr.Dataset,
+):
+
+    tree = sharrow.DataTree(tours=tours_dataset)
+    tree.add_dataset("persons", person_dataset, "tours.person_id @ persons.person_id")
+
+    assert all(tours_dataset.TourMode.cat.categories == ['Bus', 'Car', 'Walk'])
+
+    expr = "tours.TourMode == 'Bus'"
+    f = tree.setup_flow({expr:expr})
+    a = f.load_dataarray(dtype=np.int8)
+    a = a.isel(expressions=0)
+    assert all(a == np.asarray([0,1,0,0,0]))
+
+    tour_mode_bus = tree.get_expr(expr)
+    assert all(tour_mode_bus == np.asarray([0,1,0,0,0]))
+
+    work_mode_bus = tree.get_expr("WorkMode == 'Walk'")
+    assert all(work_mode_bus == np.asarray([0,0,0,0,1]))
+
+    work_mode_bus1 = tree.get_expr("persons.WorkMode == 'Walk'")
+    assert all(work_mode_bus1 == np.asarray([0,0,0,0,1]))
+
+
+def test_3_level_tree_cat(
+    tours_dataset: xr.Dataset,
+    person_dataset: xr.Dataset,
+    household_dataset: xr.Dataset,
+):
+
+    tree = sharrow.DataTree(tours=tours_dataset)
+    tree.add_dataset("persons", person_dataset, "tours.person_id @ persons.person_id")
+    tree.add_dataset("households", person_dataset, "persons.household_id @ households.household_id")
+
+    assert all(tours_dataset.TourMode.cat.categories == ['Bus', 'Car', 'Walk'])
+
+    expr = "tours.TourMode == 'Bus'"
+    f = tree.setup_flow({expr:expr})
+    a = f.load_dataarray(dtype=np.int8)
+    a = a.isel(expressions=0)
+    assert all(a == np.asarray([0,1,0,0,0]))
+
+    tour_mode_bus = tree.get_expr(expr)
+    assert all(tour_mode_bus == np.asarray([0,1,0,0,0]))
+
+    work_mode_bus = tree.get_expr("WorkMode == 'Walk'")
+    assert all(work_mode_bus == np.asarray([0,0,0,0,1]))
+
+    work_mode_bus1 = tree.get_expr("persons.WorkMode == 'Walk'")
+    assert all(work_mode_bus1 == np.asarray([0,0,0,0,1]))
+
+def test_rootless_tree_cat(
+    tours_dataset: xr.Dataset,
+    person_dataset: xr.Dataset,
+    household_dataset: xr.Dataset,
+):
+
+    tree = sharrow.DataTree(tours=tours_dataset, root_node_name=False)
+    tree.add_dataset("persons", person_dataset, "tours.person_id @ persons.person_id")
+    tree.add_dataset("households", person_dataset, "persons.household_id @ households.household_id")
+
+    assert all(tours_dataset.TourMode.cat.categories == ['Bus', 'Car', 'Walk'])
+
+    expr = "tours.TourMode == 'Bus'"
+    f = tree.setup_flow({expr:expr}, with_root_node_name="tours")
+    a = f.load_dataarray(dtype=np.int8)
+    a = a.isel(expressions=0)
+    assert all(a == np.asarray([0,1,0,0,0]))
+

--- a/sharrow/tests/test_categorical.py
+++ b/sharrow/tests/test_categorical.py
@@ -1,35 +1,25 @@
 from __future__ import annotations
 
-import shutil
-from pathlib import Path
-import os
 import numpy as np
-
-import pandas as pd
-import pytest
 import xarray as xr
 
 import sharrow
-from sharrow.dataset import construct
 
 
-
-def test_simple_cat(
-    tours_dataset: xr.Dataset
-):
+def test_simple_cat(tours_dataset: xr.Dataset):
 
     tree = sharrow.DataTree(tours=tours_dataset)
 
-    assert all(tours_dataset.TourMode.cat.categories == ['Bus', 'Car', 'Walk'])
+    assert all(tours_dataset.TourMode.cat.categories == ["Bus", "Car", "Walk"])
 
     expr = "tours.TourMode == 'Bus'"
-    f = tree.setup_flow({expr:expr})
+    f = tree.setup_flow({expr: expr})
     a = f.load_dataarray(dtype=np.int8)
     a = a.isel(expressions=0)
-    assert all(a == np.asarray([0,1,0,0,0]))
+    assert all(a == np.asarray([0, 1, 0, 0, 0]))
 
     tour_mode_bus = tree.get_expr(expr)
-    assert all(tour_mode_bus == np.asarray([0,1,0,0,0]))
+    assert all(tour_mode_bus == np.asarray([0, 1, 0, 0, 0]))
 
 
 def test_2_level_tree_cat(
@@ -40,22 +30,22 @@ def test_2_level_tree_cat(
     tree = sharrow.DataTree(tours=tours_dataset)
     tree.add_dataset("persons", person_dataset, "tours.person_id @ persons.person_id")
 
-    assert all(tours_dataset.TourMode.cat.categories == ['Bus', 'Car', 'Walk'])
+    assert all(tours_dataset.TourMode.cat.categories == ["Bus", "Car", "Walk"])
 
     expr = "tours.TourMode == 'Bus'"
-    f = tree.setup_flow({expr:expr})
+    f = tree.setup_flow({expr: expr})
     a = f.load_dataarray(dtype=np.int8)
     a = a.isel(expressions=0)
-    assert all(a == np.asarray([0,1,0,0,0]))
+    assert all(a == np.asarray([0, 1, 0, 0, 0]))
 
     tour_mode_bus = tree.get_expr(expr)
-    assert all(tour_mode_bus == np.asarray([0,1,0,0,0]))
+    assert all(tour_mode_bus == np.asarray([0, 1, 0, 0, 0]))
 
     work_mode_bus = tree.get_expr("WorkMode == 'Walk'")
-    assert all(work_mode_bus == np.asarray([0,0,0,0,1]))
+    assert all(work_mode_bus == np.asarray([0, 0, 0, 0, 1]))
 
     work_mode_bus1 = tree.get_expr("persons.WorkMode == 'Walk'")
-    assert all(work_mode_bus1 == np.asarray([0,0,0,0,1]))
+    assert all(work_mode_bus1 == np.asarray([0, 0, 0, 0, 1]))
 
 
 def test_3_level_tree_cat(
@@ -66,24 +56,27 @@ def test_3_level_tree_cat(
 
     tree = sharrow.DataTree(tours=tours_dataset)
     tree.add_dataset("persons", person_dataset, "tours.person_id @ persons.person_id")
-    tree.add_dataset("households", person_dataset, "persons.household_id @ households.household_id")
+    tree.add_dataset(
+        "households", person_dataset, "persons.household_id @ households.household_id"
+    )
 
-    assert all(tours_dataset.TourMode.cat.categories == ['Bus', 'Car', 'Walk'])
+    assert all(tours_dataset.TourMode.cat.categories == ["Bus", "Car", "Walk"])
 
     expr = "tours.TourMode == 'Bus'"
-    f = tree.setup_flow({expr:expr})
+    f = tree.setup_flow({expr: expr})
     a = f.load_dataarray(dtype=np.int8)
     a = a.isel(expressions=0)
-    assert all(a == np.asarray([0,1,0,0,0]))
+    assert all(a == np.asarray([0, 1, 0, 0, 0]))
 
     tour_mode_bus = tree.get_expr(expr)
-    assert all(tour_mode_bus == np.asarray([0,1,0,0,0]))
+    assert all(tour_mode_bus == np.asarray([0, 1, 0, 0, 0]))
 
     work_mode_bus = tree.get_expr("WorkMode == 'Walk'")
-    assert all(work_mode_bus == np.asarray([0,0,0,0,1]))
+    assert all(work_mode_bus == np.asarray([0, 0, 0, 0, 1]))
 
     work_mode_bus1 = tree.get_expr("persons.WorkMode == 'Walk'")
-    assert all(work_mode_bus1 == np.asarray([0,0,0,0,1]))
+    assert all(work_mode_bus1 == np.asarray([0, 0, 0, 0, 1]))
+
 
 def test_rootless_tree_cat(
     tours_dataset: xr.Dataset,
@@ -93,13 +86,14 @@ def test_rootless_tree_cat(
 
     tree = sharrow.DataTree(tours=tours_dataset, root_node_name=False)
     tree.add_dataset("persons", person_dataset, "tours.person_id @ persons.person_id")
-    tree.add_dataset("households", person_dataset, "persons.household_id @ households.household_id")
+    tree.add_dataset(
+        "households", person_dataset, "persons.household_id @ households.household_id"
+    )
 
-    assert all(tours_dataset.TourMode.cat.categories == ['Bus', 'Car', 'Walk'])
+    assert all(tours_dataset.TourMode.cat.categories == ["Bus", "Car", "Walk"])
 
     expr = "tours.TourMode == 'Bus'"
-    f = tree.setup_flow({expr:expr}, with_root_node_name="tours")
+    f = tree.setup_flow({expr: expr}, with_root_node_name="tours")
     a = f.load_dataarray(dtype=np.int8)
     a = a.isel(expressions=0)
-    assert all(a == np.asarray([0,1,0,0,0]))
-
+    assert all(a == np.asarray([0, 1, 0, 0, 0]))

--- a/sharrow/tests/test_datasets.py
+++ b/sharrow/tests/test_datasets.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import openmatrix
+import pandas as pd
 from pytest import approx
 
 import sharrow as sh
@@ -35,3 +36,32 @@ def test_dataset_construct_with_zoneids():
     with openmatrix.open_file(t.joinpath("dummy5.omx"), mode="r") as back:
         ds1 = sh.dataset.from_omx(back, indexes="one-based")
     assert ds1.coords["otaz"].values == approx(np.asarray([1, 2, 3, 4, 5]))
+
+
+def test_dataset_categoricals():
+    hhs = sh.example_data.get_households()
+
+    def income_cat(i):
+        if i < 12500:
+            return "LOW"
+        elif i < 45000:
+            return "MID"
+        else:
+            return "HIGH"
+
+    hhs["income_grp"] = hhs.income.apply(income_cat).astype(
+        pd.CategoricalDtype(["LOW", "MID", "HIGH"], ordered=True)
+    )
+    assert hhs["income_grp"].dtype == "category"
+
+    hd = sh.dataset.construct(hhs)
+    assert hd["income_grp"].dtype == np.int8
+
+    # affirm we can recover categorical and non-categorical data from datarrays
+    pd.testing.assert_series_equal(
+        hhs["income_grp"], hd.income_grp.single_dim.to_pandas()
+    )
+    pd.testing.assert_series_equal(hhs["income"], hd.income.single_dim.to_pandas())
+
+    recovered_df = hd.single_dim.to_pandas()
+    pd.testing.assert_frame_equal(hhs, recovered_df)

--- a/sharrow/tests/test_datastore.py
+++ b/sharrow/tests/test_datastore.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+import xarray as xr
+
+from sharrow.datastore import DataStore, ReadOnlyError
+
+
+def test_datasstore_checkpointing(tmp_path: Path, person_dataset):
+    tm = DataStore(directory=tmp_path)
+    tm["persons"] = person_dataset
+    tm.make_checkpoint("init_persons")
+
+    person_dataset["DoubleAge"] = person_dataset["Age"] * 2
+    tm.update("persons", person_dataset["DoubleAge"])
+    tm.make_checkpoint("annot_persons")
+
+    tm2 = DataStore(directory=tmp_path)
+    tm2.restore_checkpoint("annot_persons")
+    xr.testing.assert_equal(tm2.get_dataset("persons"), person_dataset)
+
+    tm2.restore_checkpoint("init_persons")
+    assert "DoubleAge" not in tm2.get_dataset("persons")
+
+    tm_ro = DataStore(directory=tmp_path, mode="r")
+    with pytest.raises(ReadOnlyError):
+        tm_ro.make_checkpoint("will-fail")
+
+
+def test_datasstore_checkpointing_parquet(tmp_path: Path, person_dataset):
+    tm = DataStore(directory=tmp_path, storage_format="parquet")
+    tm["persons"] = person_dataset
+    tm.make_checkpoint("init_persons")
+
+    person_dataset["DoubleAge"] = person_dataset["Age"] * 2
+    tm.update("persons", person_dataset["DoubleAge"])
+    tm.make_checkpoint("annot_persons")
+
+    tm2 = DataStore(directory=tmp_path)
+    tm2.restore_checkpoint("annot_persons")
+    xr.testing.assert_equal(tm2.get_dataset("persons"), person_dataset)
+
+    tm2.restore_checkpoint("init_persons")
+    assert "DoubleAge" not in tm2.get_dataset("persons")
+
+    tm_ro = DataStore(directory=tmp_path, mode="r")
+    with pytest.raises(ReadOnlyError):
+        tm_ro.make_checkpoint("will-fail")
+
+
+def test_datasstore_relationships(
+    tmp_path: Path, person_dataset, household_dataset, tours_dataset
+):
+    pth = tmp_path.joinpath("relations")
+
+    if pth.exists():
+        shutil.rmtree(pth)
+
+    pth.mkdir(parents=True, exist_ok=True)
+    tm = DataStore(directory=pth)
+
+    tm["persons"] = person_dataset
+    tm.make_checkpoint("init_persons")
+
+    tm["households"] = household_dataset
+    tm.add_relationship("persons.household_id @ households.household_id")
+    tm.make_checkpoint("init_households")
+
+    tm["tours"] = tours_dataset
+    tm.add_relationship("tours.person_id @ persons.person_id")
+    tm.make_checkpoint("init_tours")
+
+    tm.digitize_relationships()
+    assert tm.relationships_are_digitized
+
+    tm.make_checkpoint("digitized")
+
+    tm2 = DataStore(directory=pth, mode="r")
+    tm2.read_metadata("*")
+    tm2.restore_checkpoint("init_households")
+
+    assert sorted(tm2.get_dataset("persons")) == [
+        "Age",
+        "Income",
+        "Name",
+        "WorkMode",
+        "household_id",
+    ]
+
+    assert sorted(tm2.get_dataset("households")) == [
+        "n_cars",
+    ]
+
+    tm2.restore_checkpoint("digitized")
+    assert sorted(tm2.get_dataset("persons")) == [
+        "Age",
+        "Income",
+        "Name",
+        "WorkMode",
+        "digitizedOffsethousehold_id_households_household_id",
+        "household_id",
+    ]
+
+    double_age = tm2.get_dataset("persons")["Age"] * 2
+    with pytest.raises(ReadOnlyError):
+        tm2.update("persons", double_age.rename("doubleAge"))
+
+    with pytest.raises(ReadOnlyError):
+        tm2.make_checkpoint("age-x2")
+
+    tm.update("persons", double_age.rename("doubleAge"))
+    assert sorted(tm.get_dataset("persons")) == [
+        "Age",
+        "Income",
+        "Name",
+        "WorkMode",
+        "digitizedOffsethousehold_id_households_household_id",
+        "doubleAge",
+        "household_id",
+    ]
+
+    tm.make_checkpoint("age-x2")
+    tm2.read_metadata()
+    tm2.restore_checkpoint("age-x2")
+
+    person_restored = tm2.get_dataframe("persons")
+    print(person_restored.WorkMode.dtype)
+    assert person_restored.WorkMode.dtype == "category"

--- a/sharrow/tests/test_relationships.py
+++ b/sharrow/tests/test_relationships.py
@@ -30,7 +30,6 @@ def skims():
 
 
 def test_shared_data(dataframe_regression, households, skims):
-
     tree = DataTree(
         base=households,
         skims=skims,
@@ -75,7 +74,6 @@ def test_shared_data(dataframe_regression, households, skims):
 
 
 def test_subspace_fallbacks(dataframe_regression, households, skims):
-
     tree = DataTree(
         base=households,
         skims=skims,
@@ -121,7 +119,6 @@ def test_subspace_fallbacks(dataframe_regression, households, skims):
 
 
 def test_shared_data_reversible(dataframe_regression, households, skims):
-
     tree = DataTree(
         base=households,
         odt_skims=skims,
@@ -287,7 +284,6 @@ def test_with_2d_base(dataframe_regression):
 
 
 def test_mixed_dtypes(dataframe_regression, households, skims):
-
     tree = DataTree(
         base=households,
         skims=skims,
@@ -372,7 +368,6 @@ def _get_target(q, token):
     sys.version_info < (3, 8), reason="shared memory requires python3.8 or higher"
 )
 def test_shared_memory(skims):
-
     token = "skims" + secrets.token_hex(5)
 
     skims_2 = skims.shm.to_shared_memory(token)
@@ -410,7 +405,6 @@ def test_relationship_init():
 
 
 def test_replacement_filters(dataframe_regression, households, skims):
-
     tree = DataTree(
         base=households,
         skims=skims,
@@ -448,7 +442,6 @@ def test_replacement_filters(dataframe_regression, households, skims):
 
 
 def test_name_in_wrong_subspace(dataframe_regression, households, skims):
-
     tree = DataTree(
         base=households,
         skims=skims,
@@ -517,7 +510,6 @@ def test_name_in_wrong_subspace(dataframe_regression, households, skims):
 
 
 def test_shared_data_encoded(dataframe_regression, households, skims):
-
     households = sharrow.dataset.construct(households).digital_encoding.set(
         "income",
         bitwidth=32,
@@ -608,7 +600,6 @@ def test_joint_dict_encoded(dataframe_regression, skims):
 
 
 def test_isin_and_between(dataframe_regression):
-
     data = example_data.get_data()
     persons = data["persons"]
 
@@ -691,7 +682,6 @@ def test_isin_and_between(dataframe_regression):
 
 
 def test_nested_where(dataframe_regression):
-
     data = example_data.get_data()
     base = persons = data["persons"]
 
@@ -813,7 +803,6 @@ def test_isna():
 
 
 def test_get(dataframe_regression, households, skims):
-
     tree = DataTree(
         base=households,
         skims=skims,
@@ -884,8 +873,8 @@ def test_get(dataframe_regression, households, skims):
         {
             "income": "np.power(base.get('income', default=0) + df.get('missing_one', 0), 1)",
             "sov_time_by_income": "skims.SOV_TIME/np.power(base.get('income', default=0), 1)",
-            "missing_data": "np.where(np.isnan(df.get('missing_data', default=1)), 0, df.get('missing_data', default=-1))",
-            "missing_skim": "(np.where(np.isnan(df.get('num_escortees', np.nan)), -2 , df.get('num_escortees', np.nan)))",
+            "missing_data": "np.where(np.isnan(df.get('missing_data', default=1)), 0, df.get('missing_data', default=-1))",  # noqa: E501
+            "missing_skim": "(np.where(np.isnan(df.get('num_escortees', np.nan)), -2 , df.get('num_escortees', np.nan)))",  # noqa: E501
             "sov_time_by_income_2": "skims.get('SOV_TIME', default=0)/base.income",
             "sov_cost_by_income_2": "skims.get('HOV3_TIME', default=999)",
         },

--- a/sharrow/utils/tar_zst.py
+++ b/sharrow/utils/tar_zst.py
@@ -1,0 +1,104 @@
+# based on https://gist.github.com/scivision/ad241e9cf0474e267240e196d7545eca
+
+import os
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+try:
+    import zstandard  # pip install zstandard
+except ModuleNotFoundError:
+    zstandard = None
+
+
+def extract_zst(archive: Path, out_path: Path):
+    """
+    extract .zst file
+    works on Windows, Linux, MacOS, etc.
+
+    Parameters
+    ----------
+    archive: pathlib.Path or str
+      .zst file to extract
+    out_path: pathlib.Path or str
+      directory to extract files and directories to
+    """
+
+    if zstandard is None:
+        raise ImportError("pip install zstandard")
+
+    archive = Path(archive).expanduser()
+    out_path = Path(out_path).expanduser().resolve()
+    # need .resolve() in case intermediate relative dir doesn't exist
+
+    dctx = zstandard.ZstdDecompressor()
+
+    with tempfile.TemporaryFile(suffix=".tar") as ofh:
+        with archive.open("rb") as ifh:
+            dctx.copy_stream(ifh, ofh)
+        ofh.seek(0)
+        with tarfile.open(fileobj=ofh) as z:
+            z.extractall(out_path)
+
+
+def compress_zst(in_path: Path, archive: Path):
+    """
+    Compress a directory into a .tar.zst file.
+
+    Certain hidden files are excluded, including .git directories and
+    macOS's .DS_Store files.
+
+    Parameters
+    ----------
+    in_path: pathlib.Path or str
+      directory to compress
+    archive: pathlib.Path or str
+      .tar.zst file to compress into
+    """
+    if zstandard is None:
+        raise ImportError("pip install zstandard")
+    dctx = zstandard.ZstdCompressor(level=9, threads=-1, write_checksum=True)
+    with tempfile.TemporaryFile(suffix=".tar") as ofh:
+        with tarfile.open(fileobj=ofh, mode="w") as z:
+            for dirpath, dirnames, filenames in os.walk(in_path):
+                if os.path.basename(dirpath) == ".git":
+                    continue
+                for n in range(len(dirnames) - 1, -1, -1):
+                    if dirnames[n] == ".git" or dirnames[n].startswith("---"):
+                        dirnames.pop(n)
+                for f in filenames:
+                    if f.startswith(".git") or f == ".DS_Store" or f.startswith("---"):
+                        continue
+                    finame = Path(os.path.join(dirpath, f))
+                    arcname = finame.relative_to(in_path)
+                    print(f"> {arcname}")
+                    z.add(finame, arcname=arcname)
+        ofh.seek(0)
+        with archive.open("wb") as ifh:
+            dctx.copy_stream(ofh, ifh)
+
+
+if __name__ == "__main__":
+    x = Path(sys.argv[1])
+    name = x.name
+    if name.endswith(".tar.zst"):
+        y = x.with_name(name[:-8])
+        if x.exists():
+            if not y.exists():
+                print(f"extracting from: {x}")
+                extract_zst(x, y)
+            else:
+                print(f"not extracting, existing target: {y}")
+        else:
+            print(f"not extracting, does not exist: {x}")
+    else:
+        y = x.with_name(name + ".tar.zst")
+        if x.exists():
+            if not y.exists():
+                print(f"compressing to tar.zst: {x}")
+                compress_zst(x, y)
+            else:
+                print(f"not compressing, existing tar.zst: {x}")
+        else:
+            print(f"not compressing, does not exist: {x}")


### PR DESCRIPTION
- Convert pandas.CategoricalDtype into dictionary-encoded dataset variables (and back)
- Change linter from flake8 to ruff (much faster)
- Add tar-zst utility
- Clean up tags in documentation notebooks
- repair and test subspace fallbacks
- allow error on graphviz
- find "get" when inside another function
- fix root_dims
- experimental datastore class