### PR TITLE
Temp solution to look up skims using time period categorical

### DIFF
--- a/sharrow/relationships.py
+++ b/sharrow/relationships.py
@@ -1336,7 +1336,13 @@ class DataTree:
                 mapper = {i: j for (j, i) in enumerate(_dataarray_to_numpy(downstream))}
 
                 def mapper_get(x, mapper=mapper):
-                    return mapper.get(x, 0)
+                    # temp solution
+                    # when time period is a pandas categorical, x is already an int, not a string
+                    # with pandas categoricals, the indexing should not be "label", should be "position"
+                    if np.issubdtype(type(x), int):
+                        return x
+                    else:
+                        return mapper.get(x, 0)
 
                 if upstream.size:
                     offsets = xr.apply_ufunc(np.vectorize(mapper_get), upstream)


### PR DESCRIPTION
When time period string is changed to an ordered pandas categorical in the ActivitySim choosers table, Sharrow's `label` relationship does not work with time period categorical when looking up skims.  It should be something similar to `position `.

I made some workarounds in the relationship.py as a temporary solution to work with time period categorical.

@jpn-- 