### PR TITLE
Patch CI test for runtime gain

### DIFF
--- a/docs/walkthrough/one-dim.ipynb
+++ b/docs/walkthrough/one-dim.ipynb
@@ -1561,7 +1561,7 @@
     "        ),\n",
     "        number=1,\n",
     "    )\n",
-    "assert masked_time * 2 < raw_time  # generous buffer, should be nearly 7 times faster\n",
+    "assert masked_time < raw_time  # generous, should be nearly 7 times faster\n",
     "assert len(wide_flow.cache_misses[\"_imnl_plus1d\"]) == 3"
    ]
   }

--- a/sharrow/aster.py
+++ b/sharrow/aster.py
@@ -1075,7 +1075,7 @@ def expression_for_numba(
     bool_wrapping=False,
     swallow_errors=False,
     get_default=False,
-    original_expr = None,
+    original_expr=None,
 ):
     """
     Rewrite an expression so numba can compile it.

--- a/sharrow/flows.py
+++ b/sharrow/flows.py
@@ -1291,6 +1291,7 @@ class Flow:
                             extra_vars=self.tree.extra_vars,
                             blenders=blenders,
                             bool_wrapping=self.bool_wrapping,
+                            original_expr=init_expr,
                         )
                     except KeyError as key_err:
                         # there was an error, but lets make sure we process the
@@ -1306,6 +1307,7 @@ class Flow:
                             blenders=blenders,
                             bool_wrapping=self.bool_wrapping,
                             swallow_errors=True,
+                            original_expr=init_expr,
                         )
                         # Now for the fallback processing...
                         if ".." in key_err.args[0]:
@@ -1330,6 +1332,7 @@ class Flow:
                                     extra_vars=self.tree.extra_vars,
                                     blenders=blenders,
                                     bool_wrapping=self.bool_wrapping,
+                                    original_expr=init_expr,
                                 )
                             except KeyError as err:  # noqa: F841
                                 pass
@@ -1350,6 +1353,7 @@ class Flow:
                                     blenders=blenders,
                                     bool_wrapping=self.bool_wrapping,
                                     get_default=True,
+                                    original_expr=init_expr,
                                 )
                             except KeyError as err:  # noqa: F841
                                 pass
@@ -1376,6 +1380,7 @@ class Flow:
                                         blenders=blenders,
                                         bool_wrapping=self.bool_wrapping,
                                         get_default=True,
+                                        original_expr=init_expr,
                                     )
                                 except KeyError as err:  # noqa: F841
                                     pass
@@ -1417,6 +1422,7 @@ class Flow:
                                 blenders=blenders,
                                 bool_wrapping=self.bool_wrapping,
                                 get_default=gd,
+                                original_expr=init_expr,
                             )
                         except KeyError:
                             # there was an error, but lets make sure we process the
@@ -1434,6 +1440,7 @@ class Flow:
                                 bool_wrapping=self.bool_wrapping,
                                 swallow_errors=True,
                                 get_default=gd,
+                                original_expr=init_expr,
                             )
 
             # now find instances where an identifier is previously created in this flow.
@@ -1445,6 +1452,7 @@ class Flow:
                 "_outputs",
                 extra_vars=self.tree.extra_vars,
                 bool_wrapping=self.bool_wrapping,
+                original_expr=init_expr,
             )
 
             aux_tokens = {
@@ -1461,6 +1469,7 @@ class Flow:
                 prefer_name="aux_var",
                 extra_vars=self.tree.extra_vars,
                 bool_wrapping=self.bool_wrapping,
+                original_expr=init_expr,
             )
 
             if (k == init_expr) and (init_expr == expr) and k.isidentifier():


### PR DESCRIPTION
The CI tests are run on less robust servers that have inconsistent speeds.  There is one test that measures that masked array processing performance is much better than unmasked, but it is failing increasingly frequently.   This PR makes the threshold more generous to prevent (or at least discourage) failures.