### PR TITLE
Ignore skims

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ numpy >= 1.19
 pandas >= 1.2
 pyarrow >= 3.0.0
 xarray >= 0.20.0
-numba >= 0.54
+numba >= 0.57
 numexpr
 filelock
 sphinx-autosummary-accessors

--- a/envs/testing.yml
+++ b/envs/testing.yml
@@ -10,7 +10,7 @@ dependencies:
   - xarray
   - dask
   - networkx
-  - numba>=0.54
+  - numba>=0.57
   - numexpr
   - sparse
   - filelock

--- a/sharrow/dataset.py
+++ b/sharrow/dataset.py
@@ -18,6 +18,7 @@ from xarray import DataArray, Dataset
 from .accessors import register_dataset_method
 from .aster import extract_all_name_tokens
 from .categorical import _Categorical  # noqa
+from .shared_memory import si_units
 from .table import Table
 
 if TYPE_CHECKING:
@@ -624,6 +625,8 @@ def reload_from_omx_3d(
             use_file_handles.append(filename)
     omx = use_file_handles
 
+    bytes_loaded = 0
+
     try:
         t0 = time.time()
         for filename, f in zip(omx, use_file_handles):
@@ -654,8 +657,10 @@ def reload_from_omx_3d(
                         )
                     raw = dataset[data_name].data
                     raw[:, :] = f.root.data[data_name][:, :]
+                bytes_loaded += raw.nbytes
                 logger.info(
-                    f"loaded {data_name} ({filter_note}) to dataset in {time.time() - t1:.2f}s"
+                    f"loaded {data_name} ({filter_note}) to dataset "
+                    f"in {time.time() - t1:.2f}s, {si_units(bytes_loaded)}"
                 )
         logger.info(f"loading to dataset complete in {time.time() - t0:.2f}s")
     finally:

--- a/sharrow/dataset.py
+++ b/sharrow/dataset.py
@@ -5,8 +5,8 @@ import base64
 import hashlib
 import logging
 import re
-from collections.abc import Hashable, Mapping, Sequence
-from typing import Any
+from collections.abc import Hashable, Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -18,6 +18,10 @@ from .accessors import register_dataset_method
 from .aster import extract_all_name_tokens
 from .categorical import _Categorical  # noqa
 from .table import Table
+
+if TYPE_CHECKING:
+    import openmatrix
+
 
 logger = logging.getLogger("sharrow")
 
@@ -283,7 +287,7 @@ def from_table(
 
 
 def from_omx(
-    omx,
+    omx: openmatrix.File,
     index_names=("otaz", "dtaz"),
     indexes="one-based",
     renames=None,
@@ -385,8 +389,16 @@ def from_omx(
     return xr.Dataset.from_dict(d)
 
 
+def _should_ignore(ignore, x):
+    if ignore is not None:
+        for i in ignore:
+            if re.match(i, x):
+                return True
+    return False
+
+
 def from_omx_3d(
-    omx,
+    omx: openmatrix.File | str | Iterable[openmatrix.File | str],
     index_names=("otaz", "dtaz", "time_period"),
     indexes=None,
     *,
@@ -442,115 +454,207 @@ def from_omx_3d(
     if not isinstance(omx, (list, tuple)):
         omx = [omx]
 
-    # handle both larch.OMX and openmatrix.open_file versions
-    if "larch" in type(omx[0]).__module__:
-        omx_shape = omx[0].shape
-        omx_lookup = omx[0].lookup
-    else:
-        omx_shape = omx[0].shape()
-        omx_lookup = omx[0].root["lookup"]
-    omx_data = []
-    omx_data_map = {}
-    for n, i in enumerate(omx):
-        if "larch" in type(i).__module__:
-            omx_data.append(i.data)
-            for k in i.data._v_children:
-                omx_data_map[k] = n
+    use_file_handles = []
+    opened_file_handles = []
+    for filename in omx:
+        if isinstance(filename, str):
+            import openmatrix
+
+            h = openmatrix.open_file(filename)
+            opened_file_handles.append(h)
+            use_file_handles.append(h)
         else:
-            omx_data.append(i.root["data"])
-            for k in i.root["data"]._v_children:
-                omx_data_map[k] = n
+            use_file_handles.append(filename)
+    omx = use_file_handles
 
-    import dask.array
-
-    data_names = list(omx_data_map.keys())
-    if ignore is not None:
-        if isinstance(ignore, str):
-            ignore = [ignore]
-
-        def should_ignore(x):
-            if ignore is not None:
-                for i in ignore:
-                    if re.match(i, x):
-                        return True
-            return False
-
-        data_names = [i for i in data_names if not should_ignore(i)]
-    n1, n2 = omx_shape
-    if indexes is None:
-        # default reads mapping if only one lookup is included, otherwise one-based
-        if len(omx_lookup._v_children) == 1:
-            ranger = None
-            indexes = list(omx_lookup._v_children)[0]
+    try:
+        # handle both larch.OMX and openmatrix.open_file versions
+        if "larch" in type(omx[0]).__module__:
+            omx_shape = omx[0].shape
+            omx_lookup = omx[0].lookup
         else:
+            omx_shape = omx[0].shape()
+            omx_lookup = omx[0].root["lookup"]
+        omx_data = []
+        omx_data_map = {}
+        for n, i in enumerate(omx):
+            if "larch" in type(i).__module__:
+                omx_data.append(i.data)
+                for k in i.data._v_children:
+                    omx_data_map[k] = n
+            else:
+                omx_data.append(i.root["data"])
+                for k in i.root["data"]._v_children:
+                    omx_data_map[k] = n
+
+        import dask.array
+
+        data_names = list(omx_data_map.keys())
+        if ignore is not None:
+            if isinstance(ignore, str):
+                ignore = [ignore]
+            data_names = [i for i in data_names if not _should_ignore(ignore, i)]
+        n1, n2 = omx_shape
+        if indexes is None:
+            # default reads mapping if only one lookup is included, otherwise one-based
+            if len(omx_lookup._v_children) == 1:
+                ranger = None
+                indexes = list(omx_lookup._v_children)[0]
+            else:
+                ranger = one_based
+        elif indexes == "one-based":
             ranger = one_based
-    elif indexes == "one-based":
-        ranger = one_based
-    elif indexes == "zero-based":
-        ranger = zero_based
-    elif indexes in set(omx_lookup._v_children):
-        ranger = None
-    else:
-        raise NotImplementedError(
-            "only one-based, zero-based, and named indexes are implemented"
-        )
-    if ranger is not None:
-        r1 = ranger(n1)
-        r2 = ranger(n2)
-    else:
-        r1 = r2 = pd.Index(omx_lookup[indexes])
-
-    if time_periods is None:
-        raise ValueError("must give time periods explicitly")
-
-    time_periods_map = {t: n for n, t in enumerate(time_periods)}
-
-    pending_3d = {}
-    content = {}
-
-    for k in data_names:
-        if time_period_sep in k:
-            base_k, time_k = k.split(time_period_sep, 1)
-            if base_k not in pending_3d:
-                pending_3d[base_k] = [None] * len(time_periods)
-            pending_3d[base_k][time_periods_map[time_k]] = dask.array.from_array(
-                omx_data[omx_data_map[k]][k]
-            )
+        elif indexes == "zero-based":
+            ranger = zero_based
+        elif indexes in set(omx_lookup._v_children):
+            ranger = None
         else:
-            content[k] = xr.DataArray(
-                dask.array.from_array(omx_data[omx_data_map[k]][k]),
-                dims=index_names[:2],
+            raise NotImplementedError(
+                "only one-based, zero-based, and named indexes are implemented"
+            )
+        if ranger is not None:
+            r1 = ranger(n1)
+            r2 = ranger(n2)
+        else:
+            r1 = r2 = pd.Index(omx_lookup[indexes])
+
+        if time_periods is None:
+            raise ValueError("must give time periods explicitly")
+
+        time_periods_map = {t: n for n, t in enumerate(time_periods)}
+
+        pending_3d = {}
+        content = {}
+
+        for k in data_names:
+            if time_period_sep in k:
+                base_k, time_k = k.split(time_period_sep, 1)
+                if base_k not in pending_3d:
+                    pending_3d[base_k] = [None] * len(time_periods)
+                pending_3d[base_k][time_periods_map[time_k]] = dask.array.from_array(
+                    omx_data[omx_data_map[k]][k]
+                )
+            else:
+                content[k] = xr.DataArray(
+                    dask.array.from_array(omx_data[omx_data_map[k]][k]),
+                    dims=index_names[:2],
+                    coords={
+                        index_names[0]: r1,
+                        index_names[1]: r2,
+                    },
+                )
+        for base_k, darrs in pending_3d.items():
+            # find a prototype array
+            prototype = None
+            for i in darrs:
+                prototype = i
+                if prototype is not None:
+                    break
+            if prototype is None:
+                raise ValueError("no prototype")
+            darrs_ = [
+                (i if i is not None else dask.array.zeros_like(prototype))
+                for i in darrs
+            ]
+            content[base_k] = xr.DataArray(
+                dask.array.stack(darrs_, axis=-1),
+                dims=index_names,
                 coords={
                     index_names[0]: r1,
                     index_names[1]: r2,
+                    index_names[2]: time_periods,
                 },
             )
-    for base_k, darrs in pending_3d.items():
-        # find a prototype array
-        prototype = None
-        for i in darrs:
-            prototype = i
-            if prototype is not None:
-                break
-        if prototype is None:
-            raise ValueError("no prototype")
-        darrs_ = [
-            (i if i is not None else dask.array.zeros_like(prototype)) for i in darrs
-        ]
-        content[base_k] = xr.DataArray(
-            dask.array.stack(darrs_, axis=-1),
-            dims=index_names,
-            coords={
-                index_names[0]: r1,
-                index_names[1]: r2,
-                index_names[2]: time_periods,
-            },
-        )
-    for i in content:
-        if np.issubdtype(content[i].dtype, np.floating):
-            if content[i].dtype.itemsize > max_float_precision / 8:
-                content[i] = content[i].astype(f"float{max_float_precision}")
-    return xr.Dataset(content)
+        for i in content:
+            if np.issubdtype(content[i].dtype, np.floating):
+                if content[i].dtype.itemsize > max_float_precision / 8:
+                    content[i] = content[i].astype(f"float{max_float_precision}")
+        return xr.Dataset(content)
+    finally:
+        for h in opened_file_handles:
+            h.close()
+
+
+def reload_from_omx_3d(
+    dataset: xr.Dataset,
+    omx: Iterable[str],
+    *,
+    time_period_sep="__",
+    ignore=None,
+) -> None:
+    """
+    Reload the content of a dataset from OMX files.
+
+    This loads the data from the OMX files into the dataset, replacing
+    the existing data in the dataset.  The dataset must have been created
+    by `from_omx_3d` or a similar function. Note that `from_omx_3d` will
+    create a dataset backed by `dask.array` objects; this function allows for
+    loading the data without going through dask, which may have poor performance
+    on some platforms.
+
+    Parameters
+    ----------
+    dataset : xr.Dataset
+        The dataset to reload into.
+    omx : Iterable[str]
+        The list of OMX file names to load from.
+    time_period_sep : str, default "__"
+        The separator used to identify time periods in the dataset.
+    ignore : list-like, optional
+        A list of regular expressions that will be used to filter out
+        variables from the dataset.  If any of the regular expressions
+        match the name of a variable, that variable will not be included
+        in the load process. This is useful for excluding variables that
+        are not found in the target dataset.
+    """
+    if isinstance(ignore, str):
+        ignore = [ignore]
+
+    use_file_handles = []
+    opened_file_handles = []
+    for filename in omx:
+        if isinstance(filename, str):
+            import openmatrix
+
+            h = openmatrix.open_file(filename)
+            opened_file_handles.append(h)
+            use_file_handles.append(h)
+        else:
+            use_file_handles.append(filename)
+    omx = use_file_handles
+
+    try:
+        for filename in omx:
+            logger.info(f"loading into dataset from {filename}")
+            import openmatrix
+
+            with openmatrix.open_file(filename) as f:
+                for data_name in f.root.data._v_children:
+                    if _should_ignore(ignore, data_name):
+                        logger.info(f"ignoring {data_name}")
+                        continue
+                    logger.info(f"loading {data_name} to dataset")
+                    if time_period_sep in data_name:
+                        data_name_x, data_name_t = data_name.split(time_period_sep, 1)
+                        if len(dataset[data_name_x].dims) != 3:
+                            raise ValueError(
+                                f"dataset variable {data_name_x} has "
+                                f"{len(dataset[data_name_x].dims)} dimensions, expected 3"
+                            )
+                        raw = dataset[data_name_x].sel(time_period=data_name_t).data
+                        raw[:, :] = f.root.data[data_name][:, :]
+                    else:
+                        if len(dataset[data_name].dims) != 2:
+                            raise ValueError(
+                                f"dataset variable {data_name} has "
+                                f"{len(dataset[data_name].dims)} dimensions, expected 2"
+                            )
+                        raw = dataset[data_name].data
+                        raw[:, :] = f.root.data[data_name][:, :]
+        logger.info("loading to dataset complete")
+    finally:
+        for h in opened_file_handles:
+            h.close()
 
 
 def from_amx(

--- a/sharrow/dataset.py
+++ b/sharrow/dataset.py
@@ -393,6 +393,7 @@ def from_omx_3d(
     time_periods=None,
     time_period_sep="__",
     max_float_precision=32,
+    ignore=None,
 ):
     """
     Create a Dataset from an OMX file with an implicit third dimension.
@@ -457,6 +458,16 @@ def from_omx_3d(
     import dask.array
 
     data_names = list(omx_data_map.keys())
+    if ignore is not None:
+
+        def should_ignore(x):
+            if ignore is not None:
+                for i in ignore:
+                    if re.match(i, x):
+                        return True
+            return False
+
+        data_names = [i for i in data_names if not should_ignore(i)]
     n1, n2 = omx_shape
     if indexes is None:
         # default reads mapping if only one lookup is included, otherwise one-based

--- a/sharrow/dataset.py
+++ b/sharrow/dataset.py
@@ -428,6 +428,12 @@ def from_omx_3d(
         precision, generally to save memory if they were stored as double
         precision but that level of detail is unneeded in the present
         application.
+    ignore : list-like, optional
+        A list of regular expressions that will be used to filter out
+        variables from the dataset.  If any of the regular expressions
+        match the name of a variable, that variable will not be included
+        in the loaded dataset. This is useful for excluding variables that
+        are not needed in the current application.
 
     Returns
     -------
@@ -459,6 +465,8 @@ def from_omx_3d(
 
     data_names = list(omx_data_map.keys())
     if ignore is not None:
+        if isinstance(ignore, str):
+            ignore = [ignore]
 
         def should_ignore(x):
             if ignore is not None:

--- a/sharrow/example_data.py
+++ b/sharrow/example_data.py
@@ -4,6 +4,11 @@ import numpy as np
 import pandas as pd
 
 
+def get_skims_filename() -> str:
+    """Return the path to the example skims file."""
+    return os.path.join(os.path.dirname(__file__), "example_data", "skims.omx")
+
+
 def get_skims():
     import openmatrix
 

--- a/sharrow/shared_memory.py
+++ b/sharrow/shared_memory.py
@@ -280,8 +280,17 @@ class SharedMemDatasetAccessor:
             See numpy.memmap() for details.
         dask_scheduler : str, default 'threads'
             The scheduler to use when loading dask arrays into shared memory.
-            Typically "threads" for multi-threaded reads or "synchronous"
+            Typically, this is "threads" for multithreaded reads or "synchronous"
             for single-threaded reads. See dask.compute() for details.
+        pre_init : bool, default False
+            If True, the shared memory buffer will be pre-initialized with zeros.
+            This is generally not necessary, but can be useful for debugging.
+        load : bool, default True
+            If True, load the data into shared memory immediately, using dask.
+            If False, defer loading until later. Deferred tasks are stored in
+            the `shm.tasks` attribute of the resulting Dataset object, but do not
+            necessarily need to be run if data can be loaded using alternative
+            methods (e.g. `sharrow.dataset.reload_from_omx_3d`).
 
         Returns
         -------

--- a/sharrow/shared_memory.py
+++ b/sharrow/shared_memory.py
@@ -300,7 +300,7 @@ class SharedMemDatasetAccessor:
         def emit(k, a, is_coord):
             nonlocal names, wrappers, sizes, position
             if sparse is not None and isinstance(a.data, sparse.GCXS):
-                logger.info(f"preparing sparse array {a.name}")
+                logger.debug(f"preparing sparse array {a.name}")
                 wrappers.append(
                     {
                         "sparse": True,
@@ -322,7 +322,7 @@ class SharedMemDatasetAccessor:
                 )
                 a_nbytes = a.data.nbytes
             else:
-                logger.info(f"preparing dense array {a.name}")
+                logger.debug(f"preparing dense array {a.name}")
                 wrappers.append(
                     {
                         "dims": a.dims,
@@ -351,13 +351,14 @@ class SharedMemDatasetAccessor:
 
         mem = create_shared_memory_array(key, size=position)
 
-        logger.info("declaring shared memory buffer")
+        logger.debug("declaring shared memory buffer")
         if key.startswith("memmap:"):
             buffer = memoryview(mem)
         else:
             buffer = mem.buf
 
         if pre_init:
+            logger.debug("pre-initializing shared memory buffer")
             # gross init with all zeros
             buffer[:] = b"\0" * len(buffer)
 
@@ -396,7 +397,7 @@ class SharedMemDatasetAccessor:
                 mem_arr_i[:] = ad.indices[:]
                 mem_arr_p[:] = ad.indptr[:]
             else:
-                logger.info(f"preparing load task: {_name} ({si_units(_size)})")
+                logger.debug(f"preparing load task: {_name} ({si_units(_size)})")
                 mem_arr = np.ndarray(
                     shape=a.shape, dtype=a.dtype, buffer=buffer[_pos : _pos + _size]
                 )

--- a/sharrow/shared_memory.py
+++ b/sharrow/shared_memory.py
@@ -31,7 +31,11 @@ def si_units(x, kind="B", digits=3, shift=1000):
     tiers = ["n", "µ", "m", "", "K", "M", "G", "T", "P", "E", "Z", "Y"]
 
     tier = 3
-    sign = "-" if x < 0 else ""
+    try:
+        sign = "-" if x < 0 else ""
+    except TypeError:
+        # x is not a number, just return it
+        return x
     x = abs(x)
     if x > 0:
         while x > shift and tier < len(tiers):

--- a/sharrow/tests/test_datasets.py
+++ b/sharrow/tests/test_datasets.py
@@ -65,3 +65,43 @@ def test_dataset_categoricals():
 
     recovered_df = hd.single_dim.to_pandas()
     pd.testing.assert_frame_equal(hhs, recovered_df)
+
+
+def test_load_with_ignore():
+    filename = sh.example_data.get_skims_filename()
+    with openmatrix.open_file(filename) as f:
+        skims = sh.dataset.from_omx_3d(
+            f,
+            index_names=("otaz", "dtaz", "time_period"),
+            indexes=None,
+            time_periods=["EA", "AM", "MD", "PM", "EV"],
+            time_period_sep="__",
+            max_float_precision=32,
+        )
+    assert "DRV_COM_WLK_FAR" in skims.variables
+
+    with openmatrix.open_file(filename) as f:
+        skims1 = sh.dataset.from_omx_3d(
+            f,
+            index_names=("otaz", "dtaz", "time_period"),
+            indexes=None,
+            time_periods=["EA", "AM", "MD", "PM", "EV"],
+            time_period_sep="__",
+            max_float_precision=32,
+            ignore=["DRV_COM_WLK_.*"],
+        )
+    assert "DRV_COM_WLK_FAR" not in skims1.variables
+
+    with openmatrix.open_file(filename) as f:
+        skims2 = sh.dataset.from_omx_3d(
+            f,
+            index_names=("otaz", "dtaz", "time_period"),
+            indexes=None,
+            time_periods=["EA", "AM", "MD", "PM", "EV"],
+            time_period_sep="__",
+            max_float_precision=32,
+            ignore="DRV_COM_WLK_.*",
+        )
+    print(skims2)
+    assert "DISTBIKE" in skims2.variables
+    assert "DRV_COM_WLK_FAR" not in skims2.variables


### PR DESCRIPTION
This PR allow for ignoring certain skims on file load.  Also for deferring the load process, and routing data loading to commands which do not use `dask`, which has been found to have poor performance when loading very large datasets (100GB+) on Windows servers.