### PR TITLE
pin to numpy 1.x

### DIFF
--- a/envs/development.yml
+++ b/envs/development.yml
@@ -16,7 +16,7 @@ dependencies:
   - notebook
   - numba>=0.57
   - numexpr
-  - numpy>=1.19
+  - numpy>=1.19,<2
   - openmatrix
   - pandas>=1.2
   - pyarrow

--- a/envs/testing.yml
+++ b/envs/testing.yml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - pip
-  - numpy>=1.19
+  - numpy>=1.19,<2
   - pandas>=1.2
   - pyarrow
   - xarray

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "sharrow"
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
-    "numpy >= 1.19",
+    "numpy >= 1.19, <2",
     "pandas >= 1.2",
     "pyarrow",
     "xarray",


### PR DESCRIPTION
Numpy 2.0 is [breaking](https://devclass.com/2024/06/17/numpy-2-0-rolled-out-first-major-release-since-2006-comes-with-many-breaking-changes/) things.