### PR TITLE
Unparallel Runner

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -169,17 +169,18 @@ jobs:
         password: ${{ secrets.PYPI_API_TOKEN }}
   activitysim-examples:
     # test that updates to sharrow will not break the activitysim canonical examples
+    needs: fmt
     env:
       python-version: "3.10"
       label: linux-64
     strategy:
       matrix:
         include:
-          - region: Standard 1-Zone Example (MTC)
+          - region: ActivitySim 1-Zone Example (MTC)
             region-org: ActivitySim
             region-repo: activitysim-prototype-mtc
             region-branch: extended
-          - region: Standard 2-Zone Example (SANDAG)
+          - region: ActivitySim 2-Zone Example (SANDAG)
             region-org: ActivitySim
             region-repo: sandag-abm3-example
             region-branch: main

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -84,9 +84,7 @@ jobs:
       - name: Install Python and Dependencies
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
           environment-file: envs/testing.yml
           python-version: ${{ matrix.python-version }}
           activate-environment: testing-env
@@ -169,3 +167,89 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+  activitysim-examples:
+    # test that updates to sharrow will not break the activitysim canonical examples
+    env:
+      python-version: "3.10"
+      label: linux-64
+    strategy:
+      matrix:
+        include:
+          - region: Standard 1-Zone Example (MTC)
+            region-org: ActivitySim
+            region-repo: activitysim-prototype-mtc
+            region-branch: extended
+          - region: Standard 2-Zone Example (SANDAG)
+            region-org: ActivitySim
+            region-repo: sandag-abm3-example
+            region-branch: main
+      fail-fast: false
+    defaults:
+      run:
+        shell: bash -l {0}
+    name: ${{ matrix.region }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sharrow
+        uses: actions/checkout@v4
+        with:
+          path: 'sharrow'
+
+      - name: Checkout ActivitySim
+        uses: actions/checkout@v4
+        with:
+          repository: 'ActivitySim/activitysim'
+          ref: 'main'
+          path: 'activitysim'
+
+      - name: Setup Miniforge
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          activate-environment: asim-test
+          python-version: ${{ env.python-version }}
+
+      - name: Set cache date for year and month
+        run: echo "DATE=$(date +'%Y%m')" >> $GITHUB_ENV
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.CONDA }}/envs
+            ~/.cache/ActivitySim
+          key: ${{ env.label }}-conda-${{ hashFiles('activitysim/conda-environments/github-actions-tests.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+        id: cache
+
+      - name: Update environment
+        run: |
+          conda env update -n asim-test -f activitysim/conda-environments/github-actions-tests.yml
+        if: steps.cache.outputs.cache-hit != 'true'
+
+      - name: Install sharrow
+        # installing from source
+        run: |
+          python -m pip install ./sharrow
+
+      - name: Install activitysim
+        # installing without dependencies is faster, we trust that all needed dependencies
+        # are in the conda environment defined above.  Also, this avoids pip getting
+        # confused and reinstalling tables (pytables).
+        run: |
+          python -m pip install ./activitysim --no-deps
+
+      - name: Conda checkup
+        run: |
+          conda info -a
+          conda list
+
+      - name: Checkout Example
+        uses: actions/checkout@v4
+        with:
+          repository: '${{ matrix.region-org }}/${{ matrix.region-repo }}'
+          ref: '${{ matrix.region-branch }}'
+          path: '${{ matrix.region-repo }}'
+
+      - name: Test ${{ matrix.region }}
+        run: |
+          cd ${{ matrix.region-repo }}/test
+          python -m pytest .

--- a/docs/walkthrough/one-dim.ipynb
+++ b/docs/walkthrough/one-dim.ipynb
@@ -181,7 +181,7 @@
    "source": [
     "def random_tours(n_tours=100_000, seed=42):\n",
     "    rng = np.random.default_rng(seed)\n",
-    "    n_zones = skims.dims[\"dtaz\"]\n",
+    "    n_zones = skims.sizes[\"dtaz\"]\n",
     "    return pd.DataFrame(\n",
     "        {\n",
     "            \"PERID\": rng.choice(persons.index, size=n_tours),\n",
@@ -583,9 +583,52 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "39",
+   "metadata": {},
+   "source": [
+    "When the spec is large, the compile time can be significant, as the compiler can spend \n",
+    "a lot of time trying to optimize the large resulting function. In this case, it may be better to \n",
+    "use a less optimized code path, which does not involve the compiler as much.  This can\n",
+    "be done by setting the `use_array_maker` argument of the load function to `True`.  This \n",
+    "will still compile the expressions to create individual array columns, but it will not\n",
+    "try to optimize the concatenation of the columns into one large array.  Similar to regular \n",
+    "loading, the first call to the load function with the `use_array_maker` option set will\n",
+    "have some (but less) compiler overhead."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time flow.load(use_array_maker=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41",
+   "metadata": {},
+   "source": [
+    "Subsequent runs are faster because the compiled function is cached."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time flow.load(use_array_maker=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -616,7 +659,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "44",
    "metadata": {},
    "source": [
     "The load function also has some other features, like nicely formatting the output\n",
@@ -626,7 +669,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -637,7 +680,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "46",
    "metadata": {
     "tags": [
      "remove-cell"
@@ -667,7 +710,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "47",
    "metadata": {},
    "source": [
     "## Linear-in-Parameters Functions\n",
@@ -682,7 +725,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -693,7 +736,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "49",
    "metadata": {},
    "source": [
     "But `sharrow` provides a substantially faster option, by embedding\n",
@@ -704,7 +747,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -714,7 +757,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -725,7 +768,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "52",
    "metadata": {
     "tags": [
      "remove-cell"
@@ -739,7 +782,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "53",
    "metadata": {},
    "source": [
     "As before, the compiler runs only the first time we apply the this \n",
@@ -750,7 +793,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -759,7 +802,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "55",
    "metadata": {},
    "source": [
     "As for the plain `load` method, the `dot` method also has some formatted output versions.\n",
@@ -769,7 +812,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -778,7 +821,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "57",
    "metadata": {},
    "source": [
     "This works even better if the coefficients are given as a DataArray too, so it \n",
@@ -788,7 +831,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -800,7 +843,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "59",
    "metadata": {},
    "source": [
     "## Multinomial Logit Simulation\n",
@@ -816,7 +859,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -825,53 +868,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "61",
    "metadata": {},
    "source": [
     "Given those draws, we use the `logit_draws` method to build and apply a \n",
     "MNL simulator, which returns to us both the choices and the probability that\n",
-    "was computed for each chosen alternative. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "58",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "choices, choice_probs = flow.logit_draws(b, draws)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "59",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%time choices, choice_probs = flow.logit_draws(b, draws)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "60",
-   "metadata": {},
-   "source": [
-    "As this is the most complex flow processor,\n",
-    "it takes the longest to compile, but after compilation it runs quite efficiently.\n",
-    "We can see here the whole MNL simulation process for this data requires only a few \n",
-    "milliseconds more time than just computing the utilities."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "61",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "choices2, choice_probs2 = flow.logit_draws(b, draws, source=tree_2)"
+    "was computed for each chosen alternative. As previously, the first call to\n",
+    "this function triggers compilation that may take a noticable amount of time."
    ]
   },
   {
@@ -881,7 +884,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%time choices2, choice_probs2 = flow.logit_draws(b, draws, source=tree_2)"
+    "%time choices, choice_probs = flow.logit_draws(b, draws)"
    ]
   },
   {
@@ -889,7 +892,7 @@
    "id": "63",
    "metadata": {},
    "source": [
-    "The resulting choices are the index position of the choices, not the labels."
+    "Subsequent calls to the same method are much faster."
    ]
   },
   {
@@ -899,7 +902,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "choices"
+    "%time choices, choice_probs = flow.logit_draws(b, draws)"
    ]
   },
   {
@@ -907,7 +910,11 @@
    "id": "65",
    "metadata": {},
    "source": [
-    "But if we want the labels, it's easy enough to convert these indexes into labels."
+    "As this is the most complex flow processor,\n",
+    "it takes the longest to compile, but after compilation it runs quite efficiently.\n",
+    "We can see here the whole MNL simulation process for this data requires only a few \n",
+    "milliseconds more time than just computing the utilities.  The same is true even\n",
+    "after we change the data source, as we are using cached compiled code, not cached data:"
    ]
   },
   {
@@ -917,13 +924,64 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%time choices2, choice_probs2 = flow.logit_draws(b, draws, source=tree_2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67",
+   "metadata": {},
+   "source": [
+    "The resulting choices are the index position of the choices, not the labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# clean up for ruff, which does not handle %time\n",
+    "choices, choice_probs = flow.logit_draws(b, draws)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "choices"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70",
+   "metadata": {},
+   "source": [
+    "But if we want the labels, it's easy enough to convert these indexes into labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "B.modes[choices]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "72",
    "metadata": {
     "tags": [
      "remove-cell"
@@ -943,7 +1001,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -957,7 +1015,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "74",
    "metadata": {},
    "source": [
     "## Nested Logit Simulation\n",
@@ -973,7 +1031,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1003,7 +1061,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "76",
    "metadata": {
     "tags": [
      "raises-exception"
@@ -1016,7 +1074,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72",
+   "id": "77",
    "metadata": {},
    "source": [
     "Once the nesting tree is defined, it needs to be converted to operating arrays, using the `as_arrays` method (available in larch 5.7.1 and later).  Since we note estimating a nested logit model and just applying one,\n",
@@ -1026,7 +1084,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1037,7 +1095,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74",
+   "id": "79",
    "metadata": {},
    "source": [
     "This dictionary of arrays can be passed in to the `logit_draws` function to compile a nested logit model\n",
@@ -1047,7 +1105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1057,7 +1115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1067,7 +1125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1084,7 +1142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1102,7 +1160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79",
+   "id": "84",
    "metadata": {},
    "source": [
     "For nested logit models, computing just the logsums is faster than generating probabilities (and making choices) so the `logsums=1` argument allows you to short-circuit the computations if you only want the logsums."
@@ -1111,7 +1169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1121,7 +1179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1159,7 +1217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1176,12 +1234,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83",
+   "id": "88",
    "metadata": {},
    "source": [
     "Note that for consistency, the choices, probabilities of choices,\n",
     "and pick count arrays are still returned as the first three elements\n",
-    "of the returned tuple, but they're all zero-size empty arrays.\n",
+    "of the returned tuple, but they're all empty (i.e., `None`).\n",
     "\n",
     "To get *both* the logsums and the choices, set `logsums=2`."
    ]
@@ -1189,7 +1247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1199,7 +1257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1242,7 +1300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1281,7 +1339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1308,7 +1366,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88",
+   "id": "93",
    "metadata": {},
    "source": [
     "## Batch Simulation"
@@ -1316,7 +1374,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89",
+   "id": "94",
    "metadata": {},
    "source": [
     "Suppose we want to compute logsums not just for one destination, but for many destinations.  We can construct a `Dataset` with two dimensions to use at the top of our `DataTree`, one for the tours and one for the candidate destinations."
@@ -1325,7 +1383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1338,7 +1396,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91",
+   "id": "96",
    "metadata": {},
    "source": [
     "Then we can create a very similar DataTree as above, using this two dimension root Dataset, but we will point to our destination zones from the new tour dimension. and then create a flow from that."
@@ -1347,7 +1405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1383,7 +1441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1393,7 +1451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1404,7 +1462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1440,7 +1498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1454,7 +1512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1469,7 +1527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1488,7 +1546,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1506,7 +1564,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "100",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1534,7 +1592,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1568,7 +1626,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1582,7 +1640,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.14"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/walkthrough/one-dim.ipynb
+++ b/docs/walkthrough/one-dim.ipynb
@@ -474,7 +474,12 @@
     "\n",
     "np.testing.assert_array_almost_equal(actual[:5], expected[:5])\n",
     "np.testing.assert_array_almost_equal(actual[-5:], expected[-5:])\n",
-    "assert actual.shape == (len(tours), len(spec))"
+    "assert actual.shape == (len(tours), len(spec))\n",
+    "\n",
+    "actual2 = flow.load(use_array_maker=True)\n",
+    "np.testing.assert_array_almost_equal(actual2[:5], expected[:5])\n",
+    "np.testing.assert_array_almost_equal(actual2[-5:], expected[-5:])\n",
+    "assert actual2.shape == (len(tours), len(spec))"
    ]
   },
   {

--- a/sharrow/flows.py
+++ b/sharrow/flows.py
@@ -228,7 +228,7 @@ def {fname}(
 IRUNNER_1D_TEMPLATE = """
 @nb.jit(
     cache=True,
-    parallel=True,
+    parallel={parallel_irunner},
     error_model='{error_model}',
     boundscheck={boundscheck},
     nopython={nopython},
@@ -256,7 +256,7 @@ def irunner(
 IRUNNER_2D_TEMPLATE = """
 @nb.jit(
     cache=True,
-    parallel=True,
+    parallel={parallel_irunner},
     error_model='{error_model}',
     boundscheck={boundscheck},
     nopython={nopython},
@@ -285,7 +285,7 @@ def irunner(
 IDOTTER_1D_TEMPLATE = """
 @nb.jit(
     cache=True,
-    parallel=True,
+    parallel={parallel_idotter},
     error_model='{error_model}',
     boundscheck={boundscheck},
     nopython={nopython},
@@ -317,7 +317,7 @@ def idotter(
 IDOTTER_2D_TEMPLATE = """
 @nb.jit(
     cache=True,
-    parallel=True,
+    parallel={parallel_idotter},
     error_model='{error_model}',
     boundscheck={boundscheck},
     nopython={nopython},
@@ -511,7 +511,7 @@ logit_ndims = 1
 
 @nb.jit(
     cache=True,
-    parallel=True,
+    parallel={parallel},
     error_model='{error_model}',
     boundscheck={boundscheck},
     nopython={nopython},
@@ -625,7 +625,7 @@ logit_ndims = 2
 
 @nb.jit(
     cache=True,
-    parallel=True,
+    parallel={parallel},
     error_model='{error_model}',
     boundscheck={boundscheck},
     nopython={nopython},
@@ -696,7 +696,7 @@ def mnl_transform(
 
 @nb.jit(
     cache=True,
-    parallel=True,
+    parallel={parallel},
     error_model='{error_model}',
     boundscheck={boundscheck},
     nopython={nopython},
@@ -772,7 +772,7 @@ from sharrow.nested_logit import _utility_to_probability
 
 @nb.jit(
     cache=True,
-    parallel=True,
+    parallel={parallel},
     error_model='{error_model}',
     boundscheck={boundscheck},
     nopython={nopython},
@@ -918,7 +918,7 @@ class Flow:
         which can improve performance but can result in tiny distortions in
         results.  See numba docs for details.
     parallel : bool, default True
-        Enable or disable parallel computation for certain functions.
+        Enable or disable parallel computation for MNL and NL functions.
     readme : str, optional
         A string to inject as a comment at the top of the flow Python file.
     flow_library : Mapping[str,Flow], optional
@@ -957,6 +957,8 @@ class Flow:
         dim_exclude=None,
         bool_wrapping=False,
         with_root_node_name=None,
+        parallel_irunner=False,
+        parallel_idotter=True,
     ):
         assert isinstance(tree, DataTree)
         tree.digitize_relationships(inplace=True)
@@ -979,6 +981,8 @@ class Flow:
             nopython=nopython,
             fastmath=fastmath,
             bool_wrapping=bool_wrapping,
+            parallel_idotter=parallel_idotter,
+            parallel_irunner=parallel_irunner,
         )
         # return from library if available
         if flow_library is not None and self.flow_hash in flow_library:
@@ -1000,6 +1004,8 @@ class Flow:
             extra_hash_data=extra_hash_data,
             write_hash_audit=write_hash_audit,
             with_root_node_name=with_root_node_name,
+            parallel_idotter=parallel_idotter,
+            parallel_irunner=parallel_irunner,
         )
         if flow_library is not None:
             flow_library[self.flow_hash] = self
@@ -1020,6 +1026,8 @@ class Flow:
         dim_order=None,
         dim_exclude=None,
         bool_wrapping=False,
+        parallel_irunner=False,
+        parallel_idotter=True,
     ):
         """
         Initialize up to the flow_hash.
@@ -1193,6 +1201,8 @@ class Flow:
         _flow_hash_push(f"error_model={error_model}")
         _flow_hash_push(f"fastmath={fastmath}")
         _flow_hash_push(f"bool_wrapping={bool_wrapping}")
+        _flow_hash_push(f"parallel_irunner={parallel_irunner}")
+        _flow_hash_push(f"parallel_idotter={parallel_idotter}")
 
         self.flow_hash = base64.b32encode(flow_hash.digest()).decode()
         self.flow_hash_audit = "]\n# [".join(flow_hash_audit)
@@ -1520,6 +1530,9 @@ class Flow:
         extra_hash_data=(),
         write_hash_audit=True,
         with_root_node_name=None,
+        *,
+        parallel_irunner=False,
+        parallel_idotter=True,
     ):
         """
         Second step in initialization, only used if the flow is not cached.

--- a/sharrow/flows.py
+++ b/sharrow/flows.py
@@ -2653,6 +2653,9 @@ class Flow:
             modification activity is observed in the cache directory.
         mask : array-like, optional
             Only compute values for items where mask is truthy.
+        use_array_maker : bool, default False
+            Use the array_maker function to create the array. This is useful for
+            reducing compile times for complex flow specifications.
 
         Returns
         -------
@@ -2694,6 +2697,9 @@ class Flow:
             modification activity is observed in the cache directory.
         mask : array-like, optional
             Only compute values for items where mask is truthy.
+        use_array_maker : bool, default False
+            Use the array_maker function to create the array. This is useful for
+            reducing compile times for complex flow specifications.
 
         Returns
         -------
@@ -2736,6 +2742,9 @@ class Flow:
             modification activity is observed in the cache directory.
         mask : array-like, optional
             Only compute values for items where mask is truthy.
+        use_array_maker : bool, default False
+            Use the array_maker function to create the array. This is useful for
+            reducing compile times for complex flow specifications.
 
         Returns
         -------


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `sharrow` project, focusing on improving the workflow and adding new functionalities. The most significant changes include updates to the GitHub Actions workflow, new templates for array operations, and additional parameters for parallel computation.

### Workflow Enhancements

* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642R170-R256): Added a new job `activitysim-examples` to test updates to `sharrow` against ActivitySim examples. This job includes steps for setting up the environment, caching dependencies, and running tests.

### New Templates and Functions

* [`sharrow/flows.py`](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dR227-R267): Introduced `COLUMN_FILLER_TEMPLATE` and `ARRAY_MAKER_TEMPLATE` for generating functions that fill arrays and create arrays, respectively. These templates support different dimensions and improve code modularity. The array_maker approach avoids jit-compiling large functions in favor of compiling multiple smaller functions; some modest loss in compiler optimizations is sacrificed for potentially very large improvements in compile times. [[1]](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dR227-R267) [[2]](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dR321-R347)

### Parallel Computation Enhancements

* [`sharrow/flows.py`](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dR1019-R1020): Added parameters `parallel_irunner` and `parallel_idotter` to control parallel computation in various functions. The default value for `parallel_irunner` is now set to `False`. The runner is the simplest `sharrow` function, which simply assembles the flow into an array of data. Parallelism on this function provides typically only modest benefits unless data structures are very large; but compile time for parallelism has been observed to increase worse-than-linearly with larger specifications (i.e. doubling the number of spec rows results in much more than double the compile time when parallelism is active).  Parallel computation is often disabled anyhow by ActivitySim users, in which case the increased compile time provides no benefit at all.  Updated function templates to use these parameters, allowing more granular control over parallel execution. [[1]](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dR1019-R1020) [[2]](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dR1088-R1089) [[3]](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dR1263-R1264)

### Array Maker Integration

* [`sharrow/flows.py`](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dL2542-R2639): Added the option to use the new `array_maker` functions in `load`, `load_dataframe`, and `load_dataarray` methods. This allows for more flexible and efficient array creation. [[1]](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dL2542-R2639) [[2]](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dR2661-R2680) [[3]](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dR2702-R2722) [[4]](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dR2744-R2753)

### Code Refactoring

* [`sharrow/flows.py`](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dR1573-R1580): Refactored various parts of the code to integrate the new templates and improve readability. This includes changes to initialization functions and the addition of new methods for filling and creating arrays. [[1]](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dR1573-R1580) [[2]](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dL1765-R1851) [[3]](diffhunk://#diff-74198f25c9c85f6357d56ba4a240ee507d06bd8f7f9abf918e258b2b0a0e340dL1784-R1870)