### PR TITLE
don't use mamba in deploy job

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -126,9 +126,7 @@ jobs:
     - name: Install dependencies
       uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
         miniforge-version: latest
-        use-mamba: true
         environment-file: envs/testing.yml
         python-version: "3.10"
         activate-environment: testing-env
@@ -136,7 +134,7 @@ jobs:
         auto-update-conda: false
     - name: Install Jupyterbook and ruamel.yaml
       run: |
-        mamba install jupyter-book ruamel.yaml sphinx-autosummary-accessors -c conda-forge
+        conda install jupyter-book ruamel.yaml sphinx-autosummary-accessors -c conda-forge
     - name: Install sharrow
       run: |
         python -m pip install --no-deps -e .


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/run-tests.yml` file to adjust the way dependencies are installed. The most important changes involve switching from `mamba` to `conda` for package installation and removing specific `mamba` configurations.

Dependency installation adjustments:

* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L129-R137): Removed `miniforge-variant: Mambaforge` and `use-mamba: true` to simplify the setup process by using `conda` instead of `mamba`.
* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L129-R137): Changed the installation command from `mamba install` to `conda install` for `jupyter-book`, `ruamel.yaml`, and `sphinx-autosummary-accessors`.