### PR TITLE
Larch v6

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -73,5 +73,5 @@ sphinx:
       - https://arrow.apache.org/docs/
       -
       numba:
-      - https://numba.pydata.org/numba-doc/latest
+      - https://numba.readthedocs.io/en/latest
       -

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # sharrow
 
-The sharrow package is an extension of [numba](https://numba.pydata.org/), and
+The sharrow package is an extension of [numba](https://numba.readthedocs.io/), and
 offers access to data formatting and a just-in-time compiler specifically for
 converting ActivitySim-style “specification” files into optimized, runnable
 functions that “can approach the speeds of C or FORTRAN”. The idea is to pay the
@@ -8,7 +8,7 @@ cost of compiling these specification files only once, and then re-use the
 optimized results many times.
 
 This system depends only on widely used free open-source libraries, including
-[numba](https://numba.pydata.org/) and [xarray](https://xarray.pydata.org/) and
+[numba](https://numba.readthedocs.io/) and [xarray](https://xarray.pydata.org/) and
 is tested to be compatible with Windows, Linux, and macOS. Most importantly,
 using sharrow is very user friendly and requires almost no knowledge of the
 underlying mechanisms that make it speedy.  The first time a data flow is run on

--- a/envs/development.yml
+++ b/envs/development.yml
@@ -28,5 +28,5 @@ dependencies:
   - zarr
 
   - pip:
-    - larch6
+    - larch>=6
     - -e ..

--- a/envs/testing.yml
+++ b/envs/testing.yml
@@ -25,4 +25,4 @@ dependencies:
   - h5py
   - zarr
   - pip:
-    - larch6
+    - larch>=6


### PR DESCRIPTION
This pull request includes updates to documentation links and dependency specifications. The most important changes involve updating outdated URLs for the `numba` library in the documentation and modifying the version specification for the `larch` dependency in environment configuration files.

### Documentation updates:
* Updated `numba` URLs in `docs/_config.yml` and `docs/index.md` to use the new canonical documentation link (`https://numba.readthedocs.io/`) instead of the outdated link (`https://numba.pydata.org/`). [[1]](diffhunk://#diff-f64371f310bcd3bbf6ead5827d929a4eb13b7516806d6658485a996e39eb2556L76-R76) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L3-R11)

### Dependency updates:
* Updated the `larch` dependency version specification in `envs/development.yml` and `envs/testing.yml` to require version `6` or higher (`larch>=6`). [[1]](diffhunk://#diff-5f6daff8e6ec414b04ee8cd5b31d7355bd70a4d3ab7d9c3886856cedf9d811a5L31-R31) [[2]](diffhunk://#diff-d7ba5be35a1c6bafe7d2973a235d0cb87bcf4031a5be62c1bb465336030b8139L28-R28)