### PR TITLE
Improve performance by not formatting hidden code unless requested

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -177,11 +177,11 @@ jobs:
           - region: ActivitySim 1-Zone Example (MTC)
             region-org: ActivitySim
             region-repo: activitysim-prototype-mtc
-            region-branch: extended
+            region-branch: pandas2
           - region: ActivitySim 2-Zone Example (SANDAG)
             region-org: ActivitySim
             region-repo: sandag-abm3-example
-            region-branch: main
+            region-branch: pandas2
       fail-fast: false
     defaults:
       run:


### PR DESCRIPTION
When running expressions with sharrow, the tool generates a Python script full of numba functions to compile.  Before this PR, this code was passed through `black` to neatly format the generated code for easier readability and debugging.  However, for particularly large and complex sets of expressions (e.g. in ActivitySim's CDAP model) the resulting file can be thousands of lines of code, and the blackening step can be fairly slow.  Formatting is entirely unnecessary except to make debugging easier, so it can safely be disabled most of the time. This PR makes two changes: first, the formatting step will be completely skipped if it is not activated by setting the `SHARROW_BLACKEN` environment variable. Second, if formatting is called, the code will try to apply formatting with `ruff` instead of `black` (if it is available), as `ruff` is *much* faster.  

### Workflow configuration updates:
* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L180-R184): Updated the `region-branch` for two regions (`ActivitySim 1-Zone Example (MTC)` and `ActivitySim 2-Zone Example (SANDAG)`) to use the `pandas2` branch instead of their previous branches.

### Code formatting feature:
* [`sharrow/filewrite.py`](diffhunk://#diff-54f8ba7db9632ea6bb5876e70e594296537ccecbc589e5661745fb2bb1d79a30R6-R46): Added an environment variable `SHARROW_BLACKEN` to enable or disable code formatting. If enabled, the `blacken` function attempts to use `ruff` for formatting first, falling back to `black` if `ruff` is unavailable. This change also includes error handling and warnings for better debugging.