### PR TITLE
Clean up command prompt logging

### DIFF
--- a/sharrow/dataset.py
+++ b/sharrow/dataset.py
@@ -664,7 +664,7 @@ def reload_from_omx_3d(
                     raw = dataset[data_name].data
                     raw[:, :] = f.root.data[data_name][:, :]
                 bytes_loaded += raw.nbytes
-                logger.info(
+                logger.debug(
                     f"loaded {data_name} ({filter_note}) to dataset "
                     f"in {time.time() - t1:.2f}s, {si_units(bytes_loaded)}"
                 )

--- a/sharrow/flows.py
+++ b/sharrow/flows.py
@@ -1045,7 +1045,7 @@ class Flow:
         )
         # return from library if available
         if flow_library is not None and self.flow_hash in flow_library:
-            logger.info(f"flow exists in library: {self.flow_hash}")
+            logger.debug(f"flow exists in library: {self.flow_hash}")
             result = flow_library[self.flow_hash]
             result.tree = tree
             return result
@@ -1661,7 +1661,7 @@ class Flow:
         else:
             s = None
         if s and s.group(1) == self.flow_hash:
-            logger.info(f"using existing flow code {self.flow_hash}")
+            logger.debug(f"using existing flow code {self.flow_hash}")
             writing = False
         else:
             logger.info(f"writing fresh flow code {self.flow_hash}")


### PR DESCRIPTION
This is an accompanying pull request to [ActivitySim PR 1014](https://github.com/ActivitySim/activitysim/pull/1014) that downgrades a few logging statments from the `INFO` level to the `DEBUG` level to make it easier to follow the command prompt when not needing to debug as well as making it easier to sort through the logfile.