### PR TITLE
Update Ruff version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: check-yaml
   - id: end-of-file-fixer
@@ -9,13 +9,13 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/kynan/nbstripout
-  rev: 0.8.1
+  rev: 0.9.1
   hooks:
     - id: nbstripout
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.11.5
+  rev: v0.15.9
   hooks:
     # Run the linter.
     - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   rev: v0.15.9
   hooks:
     # Run the linter.
-    - id: ruff
+    - id: ruff-check
       types_or: [ python, pyi, jupyter ]
       args: [ --fix ]
     # Run the formatter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ fix = true
 line-length = 88
 target-version = "py39"
 extend-include = ["*.ipynb"]
-required-version = ">=0.11,<0.15"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
This pull request updates the project's pre-commit hooks and related tool versions to keep dependencies current and improve code quality enforcement. The most important changes are:

**Pre-commit hook updates:**

* Upgraded the `pre-commit-hooks` repository from version `v5.0.0` to `v6.0.0` in `.pre-commit-config.yaml` to include the latest checks and fixes.
* Updated the `nbstripout` hook from version `0.8.1` to `0.9.1` for better notebook output stripping.

**Ruff linter and formatter updates:**

* Upgraded the `ruff-pre-commit` hook from version `v0.11.5` to `v0.15.9` and switched the linter hook from `ruff` to `ruff-check` for improved linting and formatting capabilities.
* Removed the `required-version` constraint for Ruff in `pyproject.toml`, allowing for greater flexibility in Ruff version compatibility.